### PR TITLE
Add isPiped() method to \cli\Table

### DIFF
--- a/lib/cli/Table.php
+++ b/lib/cli/Table.php
@@ -103,7 +103,7 @@ class Table {
 			foreach ($this->_rows as $row) {
 				\cli\line($this->renderPipedRow($row));
 			}
-			exit;
+			return;
 		}
 
 		\cli\line($borderStr);


### PR DESCRIPTION
Adds a method to `\cli\Table` to check whether output is being displayed
in terminal or is being piped to another command or redirect. If output
is being piped, table should be output as tab-separated text rather than
with ASCII borders.

This is the same output behavior that other unix commands such as `mysql` 
use to determine whether to output a graphical table or tab-delimited text.
