### PR TITLE
Don't colorize piped output

### DIFF
--- a/lib/cli/Streams.php
+++ b/lib/cli/Streams.php
@@ -20,16 +20,17 @@ class Streams {
 	 */
 	public static function render( $msg ) {
 		$args = func_get_args();
+		$colorize = ( posix_isatty( static::$out ) );
 
 		// No string replacement is needed
 		if( count( $args ) == 1 ) {
-			return Colors::colorize( $msg );
+			return Colors::colorize( $msg, $colorize );
 		}
 
 		// If the first argument is not an array just pass to sprintf
 		if( !is_array( $args[1] ) ) {
 			// Colorize the message first so sprintf doesn't bitch at us
-			$args[0] = Colors::colorize( $args[0] );
+			$args[0] = Colors::colorize( $args[0], $colorize );
 			return call_user_func_array( 'sprintf', $args );
 		}
 
@@ -37,7 +38,7 @@ class Streams {
 		foreach( $args[1] as $key => $value ) {
 			$msg = str_replace( '{:' . $key . '}', $value, $msg );
 		}
-		return Colors::colorize( $msg );
+		return Colors::colorize( $msg, $colorize );
 	}
 
 	/**
@@ -227,15 +228,15 @@ class Streams {
 
 	/**
 	 * Sets one of the streams (input, output, or error) to a `stream` type resource.
-	 * 
+	 *
 	 * Valid $whichStream values are:
 	 *    - 'in'   (default: STDIN)
 	 *    - 'out'  (default: STDOUT)
 	 *    - 'err'  (default: STDERR)
-	 * 
+	 *
 	 * Any custom streams will be closed for you on shutdown, so please don't close stream
 	 * resources used with this method.
-	 * 
+	 *
 	 * @param string    $whichStream  The stream property to update
 	 * @param resource  $stream       The new stream resource to use
 	 * @return void


### PR DESCRIPTION
A followup to issue #13.

A rough POC of using the `posix_isatty()` function to determine whether or
not to colorize output. This probably needs refactoring somehow - for
one, this assumes that checking the **$out** stream is sufficient, but the
checking should be done on a per-stream basis. Also, it would be nice to
be able to pass **$colorize** into the script as a variable (for example, in 
a script that offered a `--porcelain` option), but since this function is already 
accepting so many different types of output, it would be very hard to allow 
that without breaking existing implementations.

Thoughts?
