### PR TITLE
Fix Streams::prompt()

### DIFF
--- a/lib/cli/Streams.php
+++ b/lib/cli/Streams.php
@@ -139,7 +139,7 @@ class Streams {
 
 		while( true ) {
 			\cli\Streams::out( $question . $marker );
-			$line = \cli\Streams::line();
+			$line = \cli\Streams::input();
 
 			if( !empty( $line ) )
 				return $line;
@@ -227,15 +227,15 @@ class Streams {
 
 	/**
 	 * Sets one of the streams (input, output, or error) to a `stream` type resource.
-	 * 
+	 *
 	 * Valid $whichStream values are:
 	 *    - 'in'   (default: STDIN)
 	 *    - 'out'  (default: STDOUT)
 	 *    - 'err'  (default: STDERR)
-	 * 
+	 *
 	 * Any custom streams will be closed for you on shutdown, so please don't close stream
 	 * resources used with this method.
-	 * 
+	 *
 	 * @param string    $whichStream  The stream property to update
 	 * @param resource  $stream       The new stream resource to use
 	 * @return void


### PR DESCRIPTION
Without it, if you use `\cli\choose()`, for example, it will just ignore your answer.

PS: What is the `while ( true )` loop for? Won't PHP wait for user input anyway, when calling `fgets( STDIN )` ?
