### PR TITLE
Fix escaping percent characters in content

### DIFF
--- a/lib/cli/Streams.php
+++ b/lib/cli/Streams.php
@@ -30,6 +30,10 @@ class Streams {
 		if( !is_array( $args[1] ) ) {
 			// Colorize the message first so sprintf doesn't bitch at us
 			$args[0] = Colors::colorize( $args[0] );
+
+			// Escape percent characters for sprintf
+			$args[0] = preg_replace('/(%[^\w]?)/', "%$1", $args[0]);
+
 			return call_user_func_array( 'sprintf', $args );
 		}
 


### PR DESCRIPTION
When having a percent character in your content (at least with a table) causes sprintf errors since this expects this to be a placeholder. Percent characters should therefore be escaped.

This is now fixed in the Streams class

see also 
https://github.com/jlogsdon/php-cli-tools/issues/20
