### PR TITLE
Fix %U colorization style

### DIFF
--- a/lib/cli/Colors.php
+++ b/lib/cli/Colors.php
@@ -32,7 +32,7 @@ class Colors {
 		'style' => array(
 			'bright'	 => 1,
 			'dim'		=> 2,
-			'underscore' => 4,
+			'underline' => 4,
 			'blink'	  => 5,
 			'reverse'	=> 7,
 			'hidden'	 => 8


### PR DESCRIPTION
In `Colors.php`, `%U` is mapped to `array( 'style' => 'underline' )`, but `Colors::$_colors` doesn't have an `underline` style; it has an `underscore` style.
