### PR TITLE
Default width of cmd window on Windows OS

### DIFF
--- a/lib/cli/Shell.php
+++ b/lib/cli/Shell.php
@@ -24,7 +24,10 @@ class Shell {
 	 * @todo Test on more systems.
 	 */
 	static public function columns() {
-		return exec('/usr/bin/env tput cols');
+		if( strpos( $_SERVER['OS'], 'indows' ) !== false )
+			return exec('/usr/bin/env tput cols');
+		else
+			return 80; // default width of cmd window on Windows OS, maybe force using MODE CON COLS=XXX?
 	}
 
 	/**


### PR DESCRIPTION
return 80; // default width of cmd window on Windows OS, maybe force using MODE CON COLS=XXX?
# WCEU
