### PR TITLE
Adds support for SHELL_PIPE Environment Variable

### DIFF
--- a/lib/cli/Shell.php
+++ b/lib/cli/Shell.php
@@ -45,10 +45,22 @@ class Shell {
 	 * Returns true if STDOUT output is being redirected to a pipe or a file; false is
 	 * output is being sent directly to the terminal.
 	 *
+	 * If an env variable SHELL_PIPE exists, returned result depends it's
+	 * value. Strings like 1, 0, yes, no, that validate to booleans are accepted.
+	 *
+	 * To enable ASCII formatting even when shell is piped, use the
+	 * ENV variable SHELL_PIPE=0
+	 *
 	 * @return bool
 	 */
 	static public function isPiped() {
-		return (function_exists('posix_isatty') && !posix_isatty(STDOUT));
+		$shellPipe = getenv('SHELL_PIPE');
+
+		if ($shellPipe !== false) {
+			return filter_var($shellPipe, FILTER_VALIDATE_BOOLEAN);
+		} else {
+			return (function_exists('posix_isatty') && !posix_isatty(STDOUT));
+		}
 	}
 }
 


### PR DESCRIPTION
The isPiped() method now looks for the SHELL_PIPE environment variable.
If found it returns true/false based on the value of SHELL_PIPE. If the
variable is absent existing behaviour to detect a tty remains.

Valid values are boolean strings like 1, 0, yes, no, etc.

To make the CLI ignore that the current TTY is a PIPE and thus enable
ASCII formatting, use SHELL_PIPE=0.
