### PR TITLE
Added additonal OS check in Shell::columns()

### DIFF
--- a/lib/cli/Shell.php
+++ b/lib/cli/Shell.php
@@ -27,7 +27,7 @@ class Shell {
 		static $columns;
 
 		if ( null === $columns ) {
-			if (stripos(PHP_OS, 'indows') === false) {
+			if (stripos(PHP_OS, 'indows') === false && stripos(PHP_OS, 'winnt') === false) {
 				$columns = (int) exec('/usr/bin/env tput cols');
 			}
 


### PR DESCRIPTION
Hi. I've added "WINNT" check, for Windows 8's PHP_OS value.
