### PR TITLE
Fixed static variable in class Lexer.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name":        "jlogsdon/cli",
+    "name":        "wp-cli/php-cli-tools",
     "type":        "library",
     "description": "Console utilities for PHP",
     "keywords":    ["console", "cli"],

--- a/lib/cli/arguments/Lexer.php
+++ b/lib/cli/arguments/Lexer.php
@@ -18,6 +18,7 @@ class Lexer extends Memoize implements \Iterator {
 	private $_items = array();
 	private $_index = 0;
 	private $_length = 0;
+	private $_first = true;
 
 	/**
 	 * @param array  $items  A list of strings to process as tokens.
@@ -68,11 +69,10 @@ class Lexer extends Memoize implements \Iterator {
 	 * the cursor's position to 0.
 	 */
 	public function rewind() {
-		static $first = true;
 		$this->_shift();
-		if ($first) {
+		if ($this->_first) {
 			$this->_index = 0;
-			$first = false;
+			$this->_first = false;
 		}
 	}
 


### PR DESCRIPTION
Pulled from https://github.com/wp-cli/php-cli-tools/pull/3, ignore the composer.json.

Static variables are shared between objects. In this case, we dont want this behaviour because each object has his own different properties.

To test it out, just create 2 Lexer objects and try to do 2 foreach with each one. The second object will be bugged in his loop.

This can also be tested calling 'parse' function at least twice in the same runtime.