### PR TITLE
HHVM build fails when instantiate `cli\Table` more than once

### DIFF
--- a/tests/test-table.php
+++ b/tests/test-table.php
@@ -5,7 +5,7 @@
  */
 class Test_Table extends PHPUnit_Framework_TestCase {
 
-	public function test_column_value_too_long() {
+	/*public function test_column_value_too_long() {
 
 		$constraint_width = 80;
 
@@ -33,6 +33,13 @@ class Test_Table extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( $constraint_width, strlen( $out[10] ) + 1 );
 		$this->assertEquals( $constraint_width, strlen( $out[11] ) + 1 );
 
-	}
+	}*/
 
+	/**
+	 * HHVM fails when instantiate Table more than 1 time
+	 */
+	public function test_hhvm_fail() {
+		$table1 = new cli\Table;
+		$table2 = new cli\Table;
+	}
 }


### PR DESCRIPTION
This PR is really bugreport to show that hhvm build fails in this special case.

I'm adding some acceptance tests for ASCII Tables and found that problem with hhvm.
Is hhvm really supported, planned to be supported,
or you can remove it from [travis config](https://github.com/wp-cli/php-cli-tools/blob/master/.travis.yml#L8) so I could include my tests in another PR?
