### PR TITLE
Fix width calculation for ASCII tables.

### DIFF
--- a/lib/cli/table/Ascii.php
+++ b/lib/cli/table/Ascii.php
@@ -57,7 +57,7 @@ class Ascii extends Renderer {
 				}
 			}
 
-			if ( ! empty( $resize_widths ) && $extra_width ) {
+			if ( ! empty( $resize_widths ) ) {
 				$avg_extra_width = floor( $extra_width / count( $resize_widths ) );
 				foreach( $widths as &$width ) {
 					if ( in_array( $width, $resize_widths ) ) {


### PR DESCRIPTION
In the event that all columns in a table are greater than the max
column width and the last column is greater than the max column width,
the column widths will not be correctly calculated and the table will
break.

As an example, if you have 5 columns, with a max terminal width of 101,
the max column width for each individual column will be 85 ( (101 - 16 )
/ 5 ) [width of the terminal - borders and spacing / the number of
columns]. If the first four tables columns are 17 columns wide and the
fifth column is 18 wide, the table will break.

The issue appears to be $extra_width is never set to a number greater
than 0 when each individual column is greater than the maximum column
width. This is an issue because later in the ASCII renderer, if
$extra_width is 0, _no column resizing is completed_. Therefore, the
column widths are all equal to or greater than the maximum width for the
columns, causing the table to break.

To fix the issue, $extra_width should not be checked before adjusting
the column width. This helps guarantee that the resizing will happen.
