### PR TITLE
Fix the static variable in the Lexer + fix option populating to default ...

### DIFF
--- a/lib/cli/Arguments.php
+++ b/lib/cli/Arguments.php
@@ -406,7 +406,6 @@ class Arguments implements \ArrayAccess {
 		if ($this->_strict && !empty($this->_invalid)) {
 			throw new InvalidArguments($this->_invalid);
 		}
-		Lexer::$allowRewind = true;
 	}
 
 	private function _warn($message) {
@@ -438,9 +437,16 @@ class Arguments implements \ArrayAccess {
 
 		// Peak ahead to make sure we get a value.
 		if ($this->_lexer->end() || !$this->_lexer->peek->isValue) {
-			// Oops! Got no value, throw a warning and continue.
-			$this->_warn('no value given for ' . $option->raw);
-			$this[$option->key] = null;
+			$optionSettings = $this->getOption($option->key);
+
+			if (empty($optionSettings['default'])) {
+				// Oops! Got no value and no default , throw a warning and continue.
+				$this->_warn('no value given for ' . $option->raw);
+				$this[$option->key] = null;
+			} else {
+				// No value and we have a default, so we set to the default
+				$this[$option->key] = $optionSettings['default'];
+			}
 			return true;
 		}
 

--- a/lib/cli/arguments/Lexer.php
+++ b/lib/cli/arguments/Lexer.php
@@ -18,8 +18,7 @@ class Lexer extends Memoize implements \Iterator {
 	private $_items = array();
 	private $_index = 0;
 	private $_length = 0;
-
-	public static $allowRewind = true;
+	private $_first = true;
 
 	/**
 	 * @param array  $items  A list of strings to process as tokens.
@@ -71,9 +70,9 @@ class Lexer extends Memoize implements \Iterator {
 	 */
 	public function rewind() {
 		$this->_shift();
-		if (self::$allowRewind) {
+		if ($this->_first) {
 			$this->_index = 0;
-			self::$allowRewind = false;
+			$this->_first = false;
 		}
 	}
 

--- a/tests/test-arguments.php
+++ b/tests/test-arguments.php
@@ -254,12 +254,12 @@ class TestArguments extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @todo implement once the "default" value issue has been fixed
+     * @param  array $args           arguments as they appear in the cli
+     * @param  array $expectedValues expected values after parsing
      * @dataProvider settingsWithMissingOptionsWithDefault
      */
     public function testParseWithMissingOptionsWithDefault($cliParams, $expectedValues)
     {
-        $this->markTestSkipped('Will fail cause default value is not populated. Issue #30 is still open.');
         $this->_testParse($cliParams, $expectedValues);
     }
 }


### PR DESCRIPTION
...when no value provided.

Fixed the option set to the default value when no value was provided and that the option settings had a `default` setup. (see issue https://github.com/wp-cli/php-cli-tools/issues/30)
Tests have been added for that scenario.

I had to fix the static var issue because of the penultimate test. It was triggering an exception (looks like PhpUnit catches E_USER_WARNING errors and change them to exceptions...), therefore it never got to the `Lexer::$allowRewind = true;` line and caused the following and last test to fail. I reused the fix from PR https://github.com/wp-cli/php-cli-tools/pull/55 which was much cleaner. You can close that PR BTW.

@danielbachhuber please review

