### PR TITLE
Fix widths for columns with extra lines

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,6 @@
     "autoload": {
         "psr-0": {
             "cli": "lib/"
-        },
-        "files": [
-            "lib/cli/cli.php"
-        ]
+        }
     }
 }

--- a/lib/cli/table/Ascii.php
+++ b/lib/cli/table/Ascii.php
@@ -126,7 +126,7 @@ class Ascii extends Renderer {
 		$extra_row_count = 0;
 
 		if ( count( $row ) > 0 ) {
-			$extra_rows = array();//array_fill( 0, count( $row ), array() );
+			$extra_rows = array();
 
 			foreach( $row as $col => $value ) {
 				$extra_rows[$col] = array();
@@ -167,8 +167,6 @@ class Ascii extends Renderer {
 					$col_values[] = '';
 				}
 			}
-			//ed($extra_rows, 'er');
-			//ed($extra_row_count, 'erc');
 
 			do {
 				$row_values = array();

--- a/lib/cli/table/Ascii.php
+++ b/lib/cli/table/Ascii.php
@@ -126,9 +126,10 @@ class Ascii extends Renderer {
 		$extra_row_count = 0;
 
 		if ( count( $row ) > 0 ) {
-			$extra_rows = array_fill( 0, count( $row ), array() );
+			$extra_rows = array();//array_fill( 0, count( $row ), array() );
 
 			foreach( $row as $col => $value ) {
+				$extra_rows[$col] = array();
 
 				$value = str_replace( PHP_EOL, ' ', $value );
 
@@ -166,6 +167,8 @@ class Ascii extends Renderer {
 					$col_values[] = '';
 				}
 			}
+			//ed($extra_rows, 'er');
+			//ed($extra_row_count, 'erc');
 
 			do {
 				$row_values = array();

--- a/tests/test-table-ascii.php
+++ b/tests/test-table-ascii.php
@@ -185,6 +185,32 @@ OUT;
 	}
 
 	/**
+	 * Draw a table with multiline cell
+	 *
+	 * It's only works if `tput cols` equal 120
+	 */
+	public function testDrawWithMultilineCell() {
+		$headers = array('1', '2', '3');
+		$rows = array(
+			array('A1', 'A2', 'A3 with long text with long text with long text with long text with long text with long text with long text with long text with long text with long text with long text'),
+			array('B1', 'B2', 'B3'),
+			array('C1', 'C2', 'C3')
+		);
+		$output = <<<'OUT'
++----+----+----------------------------------------------------------------------------------------------------------+
+| 1  | 2  | 3                                                                                                        |
++----+----+----------------------------------------------------------------------------------------------------------+
+| A1 | A2 | A3 with long text with long text with long text with long text with long text with long text with long t |
+|    |    | ext with long text with long text with long text with long text                                          |
+| B1 | B2 | B3                                                                                                       |
+| C1 | C2 | C3                                                                                                       |
++----+----+----------------------------------------------------------------------------------------------------------+
+
+OUT;
+		$this->assertInOutEquals(array($headers, $rows), $output);
+	}
+
+	/**
 	 * Verifies that Input and Output equals,
 	 * Sugar method for fast access from tests
 	 *

--- a/tests/test-table-ascii.php
+++ b/tests/test-table-ascii.php
@@ -197,14 +197,15 @@ OUT;
 			array('C1', 'C2', 'C3')
 		);
 		$output = <<<'OUT'
-+----+----+----------------------------------------------------------------------------------------------------------+
-| 1  | 2  | 3                                                                                                        |
-+----+----+----------------------------------------------------------------------------------------------------------+
-| A1 | A2 | A3 with long text with long text with long text with long text with long text with long text with long t |
-|    |    | ext with long text with long text with long text with long text                                          |
-| B1 | B2 | B3                                                                                                       |
-| C1 | C2 | C3                                                                                                       |
-+----+----+----------------------------------------------------------------------------------------------------------+
++----+----+-------------------------------------------------------------------+
+| 1  | 2  | 3                                                                 |
++----+----+-------------------------------------------------------------------+
+| A1 | A2 | A3 with long text with long text with long text with long text wi |
+|    |    | th long text with long text with long text with long text with lo |
+|    |    | ng text with long text with long text                             |
+| B1 | B2 | B3                                                                |
+| C1 | C2 | C3                                                                |
++----+----+-------------------------------------------------------------------+
 
 OUT;
 		$this->assertInOutEquals(array($headers, $rows), $output);


### PR DESCRIPTION
This is my quick fix for ascii table renderer.
Columns hadn't got proper widths for extra lines.
