### PR TITLE
Add retrieval of shell column length on Windows

### DIFF
--- a/lib/cli/Shell.php
+++ b/lib/cli/Shell.php
@@ -28,12 +28,21 @@ class Shell {
 		static $columns;
 
 		if ( null === $columns ) {
-			if ( ! self::is_windows() ) {
+			if (self::is_windows() ) {
+				$output = array();
+				exec('mode', $output);
+				foreach ($output as $line) {
+					if (preg_match('/Columns:( )*([0-9]+)/', $line, $matches)) {
+						$columns = (int)$matches[2];
+						break;
+					}
+				}
+			} else {
 				$columns = (int) exec('/usr/bin/env tput cols');
 			}
 
 			if ( !$columns ) {
-				$columns = 80; // default width of cmd window on Windows OS, maybe force using MODE CON COLS=XXX?
+				$columns = 80; // default width of cmd window on Windows OS
 			}
 		}
 

--- a/lib/cli/Shell.php
+++ b/lib/cli/Shell.php
@@ -30,7 +30,7 @@ class Shell {
 		if ( null === $columns ) {
 			if (self::is_windows() ) {
 				$output = array();
-				exec('mode', $output);
+				exec('mode CON', $output);
 				foreach ($output as $line) {
 					if (preg_match('/Columns:( )*([0-9]+)/', $line, $matches)) {
 						$columns = (int)$matches[2];


### PR DESCRIPTION
`cli\Shell::columns()` now supports Windows environments by parsing the output of `mode`