### PR TITLE
Verifies if exec is not in disable_functions directive

### DIFF
--- a/lib/cli/Shell.php
+++ b/lib/cli/Shell.php
@@ -37,7 +37,7 @@ class Shell {
 						break;
 					}
 				}
-			} else {
+			} else if ( !preg_match( "/(^|,)(\s*)?exec(\s*)?(,|$)/", ini_get( "disable_functions" ) ) ) {
 				$columns = (int) exec('/usr/bin/env tput cols');
 			}
 

--- a/lib/cli/Shell.php
+++ b/lib/cli/Shell.php
@@ -37,7 +37,7 @@ class Shell {
 						break;
 					}
 				}
-			} else if ( !preg_match( "/(^|,)(\s*)?exec(\s*)?(,|$)/", ini_get( "disable_functions" ) ) ) {
+			} else if (!preg_match('/(^|,)(\s*)?exec(\s*)?(,|$)/', ini_get('disable_functions'))) {
 				$columns = (int) exec('/usr/bin/env tput cols');
 			}
 


### PR DESCRIPTION
This patch fixes the warning displayed when `exec` is set in `disable_functions` directive.

`Warning: exec() has been disabled for security reasons in vendor/wp-cli/php-cli-tools/lib/cli/Shell.php on line 32`

If exec is disabled, `$columns` will assume the value set here: https://github.com/tiagohillebrandt/php-cli-tools/blob/master/lib/cli/Shell.php#L44,L46