### PR TITLE
Make "Expected" and "Actual" label the correct outputs in test results

### DIFF
--- a/tests/test-table-ascii.php
+++ b/tests/test-table-ascii.php
@@ -204,6 +204,6 @@ OUT;
 	 * @param mixed $expected Expected output
 	 */
 	private function assertOutFileEqualsWith($expected) {
-		$this->assertStringEqualsFile($this->_mockFile, $expected);
+		$this->assertEquals($expected, file_get_contents($this->_mockFile));
 	}
 }


### PR DESCRIPTION
Test cases that rely on assertOutFileEqualsWith will currently label the actual, and expected elements of the test results incorrectly. The "actual" results will be labelled as the "expected" results and vice versa.

The function currently relies on assertStringEqualsFile from PHPUnit (http://apigen.juzna.cz/doc/sebastianbergmann/phpunit/function-assertStringEqualsFile.html). This relies on the "expected" results being in the file, and the "actual" results being passed as a string. In this case however, the "actual" results are in the file, and the "expected" results are in the string. 

This PR no longer users assertStringEqualsFile, instead using assertEquals and gets the arguments in the correct place. 