### PR TITLE
Use a more impossible placeholder pattern in `Colors::colorize()`

### DIFF
--- a/lib/cli/Colors.php
+++ b/lib/cli/Colors.php
@@ -127,13 +127,13 @@ class Colors {
 			return $return;
 		}
 
-		$string = str_replace('%%', '% ', $string);
+		$string = str_replace('%%', '%¾', $string);
 
 		foreach (self::getColors() as $key => $value) {
 			$string = str_replace($key, self::color($value), $string);
 		}
 
-		$string = str_replace('% ', '%', $string);
+		$string = str_replace('%¾', '%', $string);
 		self::cacheString($passed, $string, $colored);
 
 		return $string;

--- a/tests/test-table-ascii.php
+++ b/tests/test-table-ascii.php
@@ -151,6 +151,35 @@ OUT;
 	}
 
 	/**
+	 * Test that a % is appropriately padded in the table
+	 */
+	public function testTablePaddingWithPercentCharacters() {
+		$headers = array( 'ID', 'post_title', 'post_name' );
+		$rows = array(
+			array(
+				3,
+				'10%',
+				''
+			),
+			array(
+				1,
+				'Hello world!',
+				'hello-world'
+			),
+		);
+		$output = <<<'OUT'
++----+--------------+-------------+
+| ID | post_title   | post_name   |
++----+--------------+-------------+
+| 3  | 10%          |             |
+| 1  | Hello world! | hello-world |
++----+--------------+-------------+
+
+OUT;
+		$this->assertInOutEquals(array($headers, $rows), $output);
+	}
+
+	/**
 	 * Draw wide multiplication Table.
 	 * Example with many columns, many rows
 	 */


### PR DESCRIPTION
This prevents true percent + space combinations from losing the space.

Reported in https://github.com/wp-cli/wp-cli/issues/1736