### PR TITLE
Only decolorize in `cli\safe_str_pad()` when colorizing

### DIFF
--- a/lib/cli/cli.php
+++ b/lib/cli/cli.php
@@ -202,8 +202,9 @@ function safe_substr( $str, $start, $length = false ) {
  * @return string
  */
 function safe_str_pad( $string, $length ) {
+	$cleaned_string = Colors::shouldColorize() ? Colors::decolorize( $string ) : $string;
 	// Hebrew vowel characters
-	$cleaned_string = preg_replace( '#[\x{591}-\x{5C7}]+#u', '', Colors::decolorize( $string ) );
+	$cleaned_string = preg_replace( '#[\x{591}-\x{5C7}]+#u', '', $cleaned_string );
 	if ( function_exists( 'mb_strwidth' ) && function_exists( 'mb_detect_encoding' ) ) {
 		$real_length = mb_strwidth( $cleaned_string, mb_detect_encoding( $string ) );
 	} else {

--- a/tests/test-table-ascii.php
+++ b/tests/test-table-ascii.php
@@ -74,6 +74,7 @@ OUT;
 	 * At the same time it checks that `green` defined in `cli\Colors` really looks as `green`.
 	 */
 	public function testDrawOneColumnColoredTable() {
+		Colors::enable( true );
 		$headers = array('Test Header');
 		$rows = array(
 			array(Colors::colorize('%Gx%n', true)),


### PR DESCRIPTION
If we're not colorizing, we should be calculating padding based on the
original string.