### PR TITLE
Fix Composer autoload path in examples

### DIFF
--- a/examples/common.php
+++ b/examples/common.php
@@ -9,7 +9,12 @@ ini_set('display_errors', 1);
 ini_set('log_errors', 0);
 ini_set('html_errors', 0);
 
-require_once __DIR__ . '/../vendor/autoload.php';
+foreach(array(__DIR__ . '/../vendor', __DIR__ . '/../../../../vendor') as $vendorDir) {
+	if(is_dir($vendorDir)) {
+		require_once $vendorDir . '/autoload.php';
+		break;
+	}
+}
 
 function test_notify(cli\Notify $notify, $cycle = 1000000, $sleep = null) {
 	for ($i = 0; $i <= $cycle; $i++) {


### PR DESCRIPTION
If php-cli-tools added in some project using `composer require wp-cli/php-cli-tools` then examples scripts will not work because path to `/vendor/autoload.php` will be different from path used in `/examples/common.php`.