### PR TITLE
Revert "always populate parsed arguments with default values"

### DIFF
--- a/lib/cli/Arguments.php
+++ b/lib/cli/Arguments.php
@@ -392,8 +392,6 @@ class Arguments implements \ArrayAccess {
 		$this->_parsed = array();
 		$this->_lexer = new Lexer($this->_input);
 
-		$this->_applyDefaults();
-
 		foreach ($this->_lexer as $argument) {
 			if ($this->_parseFlag($argument)) {
 				continue;
@@ -407,24 +405,6 @@ class Arguments implements \ArrayAccess {
 
 		if ($this->_strict && !empty($this->_invalid)) {
 			throw new InvalidArguments($this->_invalid);
-		}
-	}
-
-	/**
-	 * This applies the default values, if any, of all of the
-	 * flags and options, so that if there is a default value
-	 * it will be available.
-	 */
-	private function _applyDefaults() {
-		foreach($this->_flags as $flag => $settings) {
-			$this[$flag] = $settings['default'];
-		}
-
-		foreach($this->_options as $option => $settings) {
-			// If the default is 0 we should still let it be set.
-			if (!empty($settings['default']) || $settings['default'] === 0) {
-				$this[$option] = $settings['default'];
-			}
 		}
 	}
 
@@ -459,7 +439,7 @@ class Arguments implements \ArrayAccess {
 		if ($this->_lexer->end() || !$this->_lexer->peek->isValue) {
 			$optionSettings = $this->getOption($option->key);
 
-			if (empty($optionSettings['default']) && $optionSettings !== 0) {
+			if (empty($optionSettings['default'])) {
 				// Oops! Got no value and no default , throw a warning and continue.
 				$this->_warn('no value given for ' . $option->raw);
 				$this[$option->key] = null;
@@ -486,3 +466,4 @@ class Arguments implements \ArrayAccess {
 		return true;
 	}
 }
+

--- a/tests/test-arguments.php
+++ b/tests/test-arguments.php
@@ -146,7 +146,7 @@ class TestArguments extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * Data provider with valid args and options
+     * Data provider with valid fags and options
      *
      * @return array set of args and expected parsed values
      */
@@ -206,16 +206,6 @@ class TestArguments extends PHPUnit_Framework_TestCase
         );
     }
 
-    public function settingsWithNoOptionsWithDefault()
-    {
-        return array(
-            array(
-                array(),
-                array('flag1' => false, 'flag2' => false, 'option2' => 'some default value')
-            )
-        );
-    }
-
     /**
      * Generic private testParse method.
      *
@@ -270,15 +260,6 @@ class TestArguments extends PHPUnit_Framework_TestCase
      */
     public function testParseWithMissingOptionsWithDefault($cliParams, $expectedValues)
     {
-        $this->_testParse($cliParams, $expectedValues);
-    }
-
-    /**
-     * @param  array $args           arguments as they appear in the cli
-     * @param  array $expectedValues expected values after parsing
-     * @dataProvider settingsWithNoOptionsWithDefault
-     */
-    public function testParseWithNoOptionsWithDefault($cliParams, $expectedValues) {
         $this->_testParse($cliParams, $expectedValues);
     }
 }


### PR DESCRIPTION
Reverts wp-cli/php-cli-tools#97