### PR TITLE
Tags colorize support

### DIFF
--- a/lib/cli/Colors.php
+++ b/lib/cli/Colors.php
@@ -158,11 +158,11 @@ class Colors {
 			'',
 			implode('', array_keys($colors))
 		);
-		$stack = [];
+		$stack = array();
 		return preg_replace_callback(
 			"#<(/?)([$colors_keys])>#",
 			function ($match) use (&$stack, $colors) {
-				$current_colors_list = array_pop($stack) ?: [];
+				$current_colors_list = array_pop($stack) ?: array();
 				if ($match[1]) {
 					// Use previous colors
 					if (!count($stack)) {
@@ -176,7 +176,8 @@ class Colors {
 					$colors_list[] = $colors["%$match[2]"];
 					$stack[]       = $colors_list;
 				}
-				return implode('', array_map('self::color', $colors_list));
+				// PHP 5.3 doesn't allow `self::color` here:(
+				return implode('', array_map(array(__CLASS__, 'color'), $colors_list));
 			},
 			$string
 		);

--- a/lib/cli/Colors.php
+++ b/lib/cli/Colors.php
@@ -21,30 +21,30 @@ class Colors {
 	static protected $_colors = array(
 		'color' => array(
 			'black'   => 30,
-			'red'	 => 31,
+			'red'     => 31,
 			'green'   => 32,
 			'yellow'  => 33,
-			'blue'	=> 34,
+			'blue'    => 34,
 			'magenta' => 35,
-			'cyan'	=> 36,
+			'cyan'    => 36,
 			'white'   => 37
 		),
 		'style' => array(
-			'bright'	 => 1,
-			'dim'		=> 2,
+			'bright'    => 1,
+			'dim'       => 2,
 			'underline' => 4,
-			'blink'	  => 5,
-			'reverse'	=> 7,
-			'hidden'	 => 8
+			'blink'     => 5,
+			'reverse'   => 7,
+			'hidden'    => 8
 		),
 		'background' => array(
 			'black'   => 40,
-			'red'	 => 41,
+			'red'     => 41,
 			'green'   => 42,
 			'yellow'  => 43,
-			'blue'	=> 44,
+			'blue'    => 44,
 			'magenta' => 45,
-			'cyan'	=> 46,
+			'cyan'    => 46,
 			'white'   => 47
 		)
 	);
@@ -80,7 +80,7 @@ class Colors {
 	 */
 	static public function color($color) {
 		if (!is_array($color)) {
-			$color = compact('color');
+			$color = array('color' => $color);
 		}
 
 		$color += array('color' => null, 'style' => null, 'background' => null);
@@ -101,7 +101,7 @@ class Colors {
 			$colors[] = 0;
 		}
 
-		return "\033[" . join(';', $colors) . "m";
+		return "\033[" . implode(';', $colors) . "m";
 	}
 
 	/**
@@ -119,19 +119,16 @@ class Colors {
 			return self::$_string_cache[md5($passed)]['colorized'];
 		}
 
+		$colors = array_map('self::color', self::getColors());
 		if (!self::shouldColorize($colored)) {
-			$colors = self::getColors();
-			$search = array_keys( $colors );
-			$return = str_replace( $search, '', $string );
+			$return = str_replace(array_keys($colors), '', $string);
 			self::cacheString($passed, $return, $colored);
 			return $return;
 		}
 
 		$string = str_replace('%%', '%¾', $string);
 
-		foreach (self::getColors() as $key => $value) {
-			$string = str_replace($key, self::color($value), $string);
-		}
+		$string = strtr($string, $colors);
 
 		$string = str_replace('%¾', '%', $string);
 		self::cacheString($passed, $string, $colored);
@@ -146,15 +143,10 @@ class Colors {
 	 * @return string A string with color information removed.
 	 */
 	static public function decolorize($string) {
+		$colors = array_map('self::color', self::getColors());
 		// Get rid of color tokens if they exist
-		$string = str_replace(array_keys(self::getColors()), '', $string);
-
 		// Remove color encoding if it exists
-		foreach (self::getColors() as $key => $value) {
-			$string = str_replace(self::color($value), '', $string);
-		}
-
-		return $string;
+		return str_replace(array_keys($colors) + $colors, '', $string);
 	}
 
 	/**

--- a/lib/cli/Colors.php
+++ b/lib/cli/Colors.php
@@ -165,10 +165,10 @@ class Colors {
 				$current_colors_list = array_pop($stack) ?: array();
 				if ($match[1]) {
 					// Use previous colors
-					if (!count($stack)) {
-						return '';
-					}
 					$colors_list = $stack[count($stack) - 1];
+					if (!$colors_list) {
+						$colors_list = $colors['%n'];
+					}
 				} else {
 					// Mix current colors with new color
 					$stack[]       = $current_colors_list;

--- a/tests/test-cli.php
+++ b/tests/test-cli.php
@@ -60,6 +60,21 @@ class testsCli extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( \cli\Colors::colorize( $original, false ), 'x' );
 	}
 
+	function test_colorize_string_with_tags_is_colored() {
+		// Bright green `x` and bright green on blue background `y`
+		$original = '<G>x<4>y</4></G>';
+		$colorized = "\033[32;1mx\033[32;1m\033[44my\033[32;1m";
+
+		$this->assertEquals( \cli\Colors::colorize( $original, true ), $colorized );
+	}
+
+	function test_colorize_string_with_tags_no_closing_tag() {
+		$original = '<G>x';
+		$colorized = "\033[32;1mx";
+
+		$this->assertEquals( \cli\Colors::colorize( $original, true ), $colorized );
+	}
+
 	function test_binary_string_is_converted_back_to_original_string() {
 		$string            = 'x';
 		$string_with_color = '%b' . $string;
@@ -70,6 +85,7 @@ class testsCli extends PHPUnit_Framework_TestCase {
 
 		// Ensure that the colorization is reverted
 		$this->assertEquals( \cli\Colors::decolorize( $colorized_string ), $string );
+		$this->assertEquals( \cli\Colors::decolorize( "%b<b>$colorized_string" ), $string );
 	}
 
 	function test_string_cache() {

--- a/tests/test-cli.php
+++ b/tests/test-cli.php
@@ -63,7 +63,7 @@ class testsCli extends PHPUnit_Framework_TestCase {
 	function test_colorize_string_with_tags_is_colored() {
 		// Bright green `x` and bright green on blue background `y`
 		$original = '<G>x<4>y</4></G>';
-		$colorized = "\033[32;1mx\033[32;1m\033[44my\033[32;1m";
+		$colorized = "\033[32;1mx\033[32;1m\033[44my\033[32;1m\033[0m";
 
 		$this->assertEquals( \cli\Colors::colorize( $original, true ), $colorized );
 	}


### PR DESCRIPTION
This is implementation of what I was talking in #96

Essentially, allows using HTML-like formatting:

``` html
<g>Green text <4>still green, but blue background</4> just green again</g>
```

in addition to less convenient (current syntax)

```
%gGreen text %4still green, but blue background%n%g just green again
```

It is much easier to read, write and maintain. Please, refer to #96 for discussion.
Nothing is removed and/or deprecated, unless you're using `<g>` and similar tags for whatever reason in CLI output, it shouldn't introduce any backward compatibility problems.

Fixes #96.
