### PR TITLE
Bring back default values and fix tests

### DIFF
--- a/lib/cli/Arguments.php
+++ b/lib/cli/Arguments.php
@@ -392,6 +392,8 @@ class Arguments implements \ArrayAccess {
 		$this->_parsed = array();
 		$this->_lexer = new Lexer($this->_input);
 
+		$this->_applyDefaults();
+
 		foreach ($this->_lexer as $argument) {
 			if ($this->_parseFlag($argument)) {
 				continue;
@@ -405,6 +407,24 @@ class Arguments implements \ArrayAccess {
 
 		if ($this->_strict && !empty($this->_invalid)) {
 			throw new InvalidArguments($this->_invalid);
+		}
+	}
+
+	/**
+	 * This applies the default values, if any, of all of the
+	 * flags and options, so that if there is a default value
+	 * it will be available.
+	 */
+	private function _applyDefaults() {
+		foreach($this->_flags as $flag => $settings) {
+			$this[$flag] = $settings['default'];
+		}
+
+		foreach($this->_options as $option => $settings) {
+			// If the default is 0 we should still let it be set.
+			if (!empty($settings['default']) || $settings['default'] === 0) {
+				$this[$option] = $settings['default'];
+			}
 		}
 	}
 
@@ -439,7 +459,7 @@ class Arguments implements \ArrayAccess {
 		if ($this->_lexer->end() || !$this->_lexer->peek->isValue) {
 			$optionSettings = $this->getOption($option->key);
 
-			if (empty($optionSettings['default'])) {
+			if (empty($optionSettings['default']) && $optionSettings !== 0) {
 				// Oops! Got no value and no default , throw a warning and continue.
 				$this->_warn('no value given for ' . $option->raw);
 				$this[$option->key] = null;
@@ -466,4 +486,3 @@ class Arguments implements \ArrayAccess {
 		return true;
 	}
 }
-

--- a/tests/test-arguments.php
+++ b/tests/test-arguments.php
@@ -231,7 +231,7 @@ class TestArguments extends PHPUnit_Framework_TestCase
 
         foreach ($expectedValues as $name => $value) {
             if ($args->isFlag($name)) {
-                $this->assertTrue($args[$name]);
+                $this->assertEquals($value, $args[$name]);
             }
 
             if ($args->isOption($name)) {

--- a/tests/test-arguments.php
+++ b/tests/test-arguments.php
@@ -146,7 +146,7 @@ class TestArguments extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * Data provider with valid fags and options
+     * Data provider with valid args and options
      *
      * @return array set of args and expected parsed values
      */
@@ -206,6 +206,16 @@ class TestArguments extends PHPUnit_Framework_TestCase
         );
     }
 
+    public function settingsWithNoOptionsWithDefault()
+    {
+        return array(
+            array(
+                array(),
+                array('flag1' => false, 'flag2' => false, 'option2' => 'some default value')
+            )
+        );
+    }
+
     /**
      * Generic private testParse method.
      *
@@ -260,6 +270,15 @@ class TestArguments extends PHPUnit_Framework_TestCase
      */
     public function testParseWithMissingOptionsWithDefault($cliParams, $expectedValues)
     {
+        $this->_testParse($cliParams, $expectedValues);
+    }
+
+    /**
+     * @param  array $args           arguments as they appear in the cli
+     * @param  array $expectedValues expected values after parsing
+     * @dataProvider settingsWithNoOptionsWithDefault
+     */
+    public function testParseWithNoOptionsWithDefault($cliParams, $expectedValues) {
         $this->_testParse($cliParams, $expectedValues);
     }
 }


### PR DESCRIPTION
"always populate parsed arguments with default values" was implemented in PR https://github.com/wp-cli/php-cli-tools/pull/97 but reverted later because of a failing test. 

This PR brings the feature back (revert the revert) and fixes the failing test. The fix is very small and can be reviewed in https://github.com/Luxian/php-cli-tools/commit/f5080ac86b9719b2a732180a55b809e0b247fffa

Closes issue #30 

