### PR TITLE
Shell:columns(): Better calc on Windows. Check TERM. Make testable.

### DIFF
--- a/lib/cli/Shell.php
+++ b/lib/cli/Shell.php
@@ -34,7 +34,7 @@ class Shell {
 			if ( function_exists( 'exec' ) ) {
 				if ( self::is_windows() ) {
 					// Cater for shells such as Cygwin and Git bash where `mode CON` returns an incorrect value for columns.
-					if ( ( $shell = getenv( 'SHELL' ) ) && preg_match( '/(?:bash|zsh)(?:.exe)?$/', $shell ) && getenv( 'TERM' ) ) {
+					if ( ( $shell = getenv( 'SHELL' ) ) && preg_match( '/(?:bash|zsh)(?:\.exe)?$/', $shell ) && getenv( 'TERM' ) ) {
 						$columns = (int) exec( 'tput cols' );
 					}
 					if ( ! $columns ) {

--- a/lib/cli/Shell.php
+++ b/lib/cli/Shell.php
@@ -27,7 +27,7 @@ class Shell {
 	static public function columns() {
 		static $columns;
 
-		if ( getenv( 'WP_CLI_TEST_SHELL_COLUMNS_RESET' ) ) {
+		if ( getenv( 'PHP_CLI_TOOLS_TEST_SHELL_COLUMNS_RESET' ) ) {
 			$columns = null;
 		}
 		if ( null === $columns ) {

--- a/lib/cli/Shell.php
+++ b/lib/cli/Shell.php
@@ -21,27 +21,43 @@ class Shell {
 	/**
 	 * Returns the number of columns the current shell has for display.
 	 *
+	 * @param mixed $test For testing only.
+	 *
 	 * @return int  The number of columns.
 	 * @todo Test on more systems.
 	 */
-	static public function columns() {
+	static public function columns( $test = null ) {
 		static $columns;
 
+		if ( null !== $test ) {
+			$columns = null;
+		}
 		if ( null === $columns ) {
-			if (self::is_windows() ) {
-				$output = array();
-				exec('mode CON', $output);
-				foreach ($output as $line) {
-					if (preg_match('/Columns:( )*([0-9]+)/', $line, $matches)) {
-						$columns = (int)$matches[2];
-						break;
+			if ( function_exists( 'exec' ) ) {
+				if ( self::is_windows( 'WIN' === $test ) ) {
+					// Cater for shells such as Cygwin and Git bash where `mode CON` returns an incorrect value for columns.
+					if ( ( $shell = getenv( 'SHELL' ) ) && preg_match( '/(?:bash|zsh)(?:.exe)?$/', $shell ) && getenv( 'TERM' ) ) {
+						$columns = (int) exec( 'tput cols' );
+					}
+					if ( ! $columns ) {
+						$return_var = -1;
+						$output = array();
+						exec( 'mode CON', $output, $return_var );
+						if ( 0 === $return_var && $output ) {
+							// Look for second line ending in ": <number>" (searching for "Columns:" will fail on non-English locales).
+							if ( preg_match( '/:\s*[0-9]+\n[^:]+:\s*([0-9]+)\n/', implode( "\n", $output ), $matches ) ) {
+								$columns = (int) $matches[1];
+							}
+						}
+					}
+				} else {
+					if ( getenv( 'TERM' ) ) {
+						$columns = (int) exec( '/usr/bin/env tput cols' );
 					}
 				}
-			} else if (!preg_match('/(^|,)(\s*)?exec(\s*)?(,|$)/', ini_get('disable_functions'))) {
-				$columns = (int) exec('/usr/bin/env tput cols');
 			}
 
-			if ( !$columns ) {
+			if ( ! $columns ) {
 				$columns = 80; // default width of cmd window on Windows OS
 			}
 		}

--- a/lib/cli/Shell.php
+++ b/lib/cli/Shell.php
@@ -21,20 +21,18 @@ class Shell {
 	/**
 	 * Returns the number of columns the current shell has for display.
 	 *
-	 * @param mixed $test For testing only.
-	 *
 	 * @return int  The number of columns.
 	 * @todo Test on more systems.
 	 */
-	static public function columns( $test = null ) {
+	static public function columns() {
 		static $columns;
 
-		if ( null !== $test ) {
+		if ( false !== ( $env_reset = getenv( 'WP_CLI_TEST_SHELL_COLUMNS_RESET' ) ) && $env_reset ) {
 			$columns = null;
 		}
 		if ( null === $columns ) {
 			if ( function_exists( 'exec' ) ) {
-				if ( self::is_windows( 'WIN' === $test ) ) {
+				if ( self::is_windows() ) {
 					// Cater for shells such as Cygwin and Git bash where `mode CON` returns an incorrect value for columns.
 					if ( ( $shell = getenv( 'SHELL' ) ) && preg_match( '/(?:bash|zsh)(?:.exe)?$/', $shell ) && getenv( 'TERM' ) ) {
 						$columns = (int) exec( 'tput cols' );

--- a/lib/cli/Shell.php
+++ b/lib/cli/Shell.php
@@ -27,7 +27,7 @@ class Shell {
 	static public function columns() {
 		static $columns;
 
-		if ( false !== ( $env_reset = getenv( 'WP_CLI_TEST_SHELL_COLUMNS_RESET' ) ) && $env_reset ) {
+		if ( getenv( 'WP_CLI_TEST_SHELL_COLUMNS_RESET' ) ) {
 			$columns = null;
 		}
 		if ( null === $columns ) {

--- a/tests/test-shell.php
+++ b/tests/test-shell.php
@@ -14,26 +14,40 @@ class TestShell extends PHPUnit_Framework_TestCase {
 		// Save.
 		$env_term = getenv( 'TERM' );
 		$env_columns = getenv( 'COLUMNS' );
+		$env_is_windows = getenv( 'WP_CLI_TEST_IS_WINDOWS' );
+		$env_shell_columns_reset = getenv( 'WP_CLI_TEST_SHELL_COLUMNS_RESET' );
+
+		putenv( 'WP_CLI_TEST_SHELL_COLUMNS_RESET=1' );
 
 		// No TERM should result in default 80.
 
 		putenv( 'TERM' );
-		$columns = cli\Shell::columns( true /*test*/ );
+
+		putenv( 'WP_CLI_TEST_IS_WINDOWS=0' );
+		$columns = cli\Shell::columns();
 		$this->assertSame( 80, $columns );
-		$columns = cli\Shell::columns( 'WIN' /*test*/ );
+
+		putenv( 'WP_CLI_TEST_IS_WINDOWS=1' );
+		$columns = cli\Shell::columns();
 		$this->assertSame( 80, $columns );
 
 		// TERM and COLUMNS should result in whatever COLUMNS is.
 
 		putenv( 'TERM=vt100' );
 		putenv( 'COLUMNS=100' );
-		$columns = cli\Shell::columns( true /*test*/ );
+
+		putenv( 'WP_CLI_TEST_IS_WINDOWS=0' );
+		$columns = cli\Shell::columns();
 		$this->assertSame( 100, $columns );
-		$columns = cli\Shell::columns( 'WIN' /*test*/ );
+
+		putenv( 'WP_CLI_TEST_IS_WINDOWS=1' );
+		$columns = cli\Shell::columns();
 		$this->assertSame( 100, $columns );
 
 		// Restore.
 		putenv( false === $env_term ? 'TERM' : "TERM=$env_term" );
 		putenv( false === $env_columns ? 'COLUMNS' : "COLUMNS=$env_columns" );
+		putenv( false === $env_is_windows ? 'WP_CLI_TEST_IS_WINDOWS' : "WP_CLI_TEST_IS_WINDOWS=$env_is_windows" );
+		putenv( false === $env_shell_columns_reset ? 'WP_CLI_TEST_SHELL_COLUMNS_RESET' : "WP_CLI_TEST_SHELL_COLUMNS_RESET=$env_shell_columns_reset" );
 	}
 }

--- a/tests/test-shell.php
+++ b/tests/test-shell.php
@@ -15,9 +15,9 @@ class TestShell extends PHPUnit_Framework_TestCase {
 		$env_term = getenv( 'TERM' );
 		$env_columns = getenv( 'COLUMNS' );
 		$env_is_windows = getenv( 'WP_CLI_TEST_IS_WINDOWS' );
-		$env_shell_columns_reset = getenv( 'WP_CLI_TEST_SHELL_COLUMNS_RESET' );
+		$env_shell_columns_reset = getenv( 'PHP_CLI_TOOLS_TEST_SHELL_COLUMNS_RESET' );
 
-		putenv( 'WP_CLI_TEST_SHELL_COLUMNS_RESET=1' );
+		putenv( 'PHP_CLI_TOOLS_TEST_SHELL_COLUMNS_RESET=1' );
 
 		// No TERM should result in default 80.
 
@@ -48,6 +48,6 @@ class TestShell extends PHPUnit_Framework_TestCase {
 		putenv( false === $env_term ? 'TERM' : "TERM=$env_term" );
 		putenv( false === $env_columns ? 'COLUMNS' : "COLUMNS=$env_columns" );
 		putenv( false === $env_is_windows ? 'WP_CLI_TEST_IS_WINDOWS' : "WP_CLI_TEST_IS_WINDOWS=$env_is_windows" );
-		putenv( false === $env_shell_columns_reset ? 'WP_CLI_TEST_SHELL_COLUMNS_RESET' : "WP_CLI_TEST_SHELL_COLUMNS_RESET=$env_shell_columns_reset" );
+		putenv( false === $env_shell_columns_reset ? 'PHP_CLI_TOOLS_TEST_SHELL_COLUMNS_RESET' : "PHP_CLI_TOOLS_TEST_SHELL_COLUMNS_RESET=$env_shell_columns_reset" );
 	}
 }

--- a/tests/test-shell.php
+++ b/tests/test-shell.php
@@ -1,0 +1,39 @@
+<?php
+
+use cli\Shell;
+
+/**
+ * Class TestShell
+ */
+class TestShell extends PHPUnit_Framework_TestCase {
+
+    /**
+     * Test getting TERM columns.
+     */
+    function testColumns() {
+		// Save.
+		$env_term = getenv( 'TERM' );
+		$env_columns = getenv( 'COLUMNS' );
+
+		// No TERM should result in default 80.
+
+		putenv( 'TERM' );
+		$columns = cli\Shell::columns( true /*test*/ );
+		$this->assertSame( 80, $columns );
+		$columns = cli\Shell::columns( 'WIN' /*test*/ );
+		$this->assertSame( 80, $columns );
+
+		// TERM and COLUMNS should result in whatever COLUMNS is.
+
+		putenv( 'TERM=vt100' );
+		putenv( 'COLUMNS=100' );
+		$columns = cli\Shell::columns( true /*test*/ );
+		$this->assertSame( 100, $columns );
+		$columns = cli\Shell::columns( 'WIN' /*test*/ );
+		$this->assertSame( 100, $columns );
+
+		// Restore.
+		putenv( false === $env_term ? 'TERM' : "TERM=$env_term" );
+		putenv( false === $env_columns ? 'COLUMNS' : "COLUMNS=$env_columns" );
+	}
+}


### PR DESCRIPTION
Issue https://github.com/wp-cli/wp-cli/issues/4127

Caters for bash-like shells on Windows that return incorrect columns using `mode CON`.

Checks that `TERM` env var exists before using `tput` otherwise it will write stuff to STDERR, which messes up tests.

Makes testable with env var `WP_CLI_TEST_SHELL_COLUMNS_RESET` to reset the `$columns` static.

Uses `function_exists()` rather than checking `disable_functions` ini directive as it's more reliable (though to be totally correct should also check suhosin whitelist/blacklist).

Parses output of `mode CON` in a locale-indifferent way.
