### PR TITLE
Incorrect table column width with multibyte text.

### DIFF
--- a/lib/cli/cli.php
+++ b/lib/cli/cli.php
@@ -204,10 +204,10 @@ function safe_substr( $str, $start, $length = false ) {
 function safe_str_pad( $string, $length ) {
 	$cleaned_string = Colors::shouldColorize() ? Colors::decolorize( $string ) : $string;
 	$real_length = strwidth( $cleaned_string );
-	$diff = strlen( $string ) - $real_length;
+	$diff = mb_strwidth( $string ) - $real_length;
 	$length += $diff;
 
-	return str_pad( $string, $length );
+	return mb_str_pad( $string, $length );
 }
 
 /**

--- a/lib/cli/cli.php
+++ b/lib/cli/cli.php
@@ -175,7 +175,7 @@ function safe_strlen( $str ) {
 /**
  * Attempts an encoding-safe way of getting a substring. If mb_string extensions aren't
  * installed, falls back to ascii substring if no encoding is present
- * 		
+ *
  * @param  string  $str  The input string
  * @param  int     $start   The starting position of the substring
  * @param  boolean $length  Maximum length of the substring
@@ -187,7 +187,7 @@ function safe_substr( $str, $start, $length = false ) {
 	} else {
 		// iconv will return PHP notice if non-ascii characters are present in input string
 		$str = iconv( 'ASCII' , 'ASCII', $str );
-		
+
 		$substr = substr( $str, $start, $length );
 	}
 
@@ -251,4 +251,11 @@ function strwidth( $string ) {
 		}
 	}
 	return safe_strlen( $string );
+}
+
+
+function mb_str_pad( $str, $pad_len ) {
+	$pad_str = str_repeat( ' ', $pad_len );
+	$after = mb_substr( $pad_str, mb_strwidth( $str ) );
+	return $str . $after;
 }

--- a/tests/test-cli.php
+++ b/tests/test-cli.php
@@ -57,7 +57,7 @@ class testsCli extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( 9, mb_strwidth( \cli\safe_str_pad( 'hello', 9 ) ) );
 		$this->assertEquals( 9, mb_strwidth( \cli\safe_str_pad( 'óra', 9 ) ) ); // special characters take one byte
 		$this->assertEquals( 9, mb_strwidth( \cli\safe_str_pad( '日本語', 9 ) ) ); // each character takes two bytes
-		//$this->assertEquals( 9, mb_strwidth( \cli\safe_str_pad( 'עִבְרִית', 9 ) ) ); // process Hebrew vowels
+		$this->assertEquals( 9, mb_strwidth( \cli\safe_str_pad( 'עִבְרִית', 9 ) ) ); // process Hebrew vowels
 	}
 
 	function test_colorized_string_pad() {

--- a/tests/test-cli.php
+++ b/tests/test-cli.php
@@ -44,6 +44,22 @@ class testsCli extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( 17, strlen( \cli\Colors::pad( 'עִבְרִית', 6 ) ) ); // process Hebrew vowels
 	}
 
+	function test_mb_str_pad() {
+
+		$this->assertEquals( 9, mb_strwidth( \cli\mb_str_pad( 'hello', 9 ) ) );
+		$this->assertEquals( 9, mb_strwidth( \cli\mb_str_pad( 'óra', 9 ) ) ); // special characters take one byte
+		$this->assertEquals( 9, mb_strwidth( \cli\mb_str_pad( '日本語', 9 ) ) ); // each character takes two bytes
+		$this->assertEquals( 9, mb_strwidth( \cli\mb_str_pad( 'עִבְרִית', 9 ) ) ); // process Hebrew vowels
+	}
+
+	function test_safe_str_pad() {
+
+		$this->assertEquals( 9, mb_strwidth( \cli\safe_str_pad( 'hello', 9 ) ) );
+		$this->assertEquals( 9, mb_strwidth( \cli\safe_str_pad( 'óra', 9 ) ) ); // special characters take one byte
+		$this->assertEquals( 9, mb_strwidth( \cli\safe_str_pad( '日本語', 9 ) ) ); // each character takes two bytes
+		//$this->assertEquals( 9, mb_strwidth( \cli\safe_str_pad( 'עִבְרִית', 9 ) ) ); // process Hebrew vowels
+	}
+
 	function test_colorized_string_pad() {
 		$this->assertEquals( 22, strlen( \cli\Colors::pad( \cli\Colors::colorize( "%Gx%n", true ), 11 ))); // colorized `x` string
 		$this->assertEquals( 23, strlen( \cli\Colors::pad( \cli\Colors::colorize( "%Góra%n", true ), 11 ))); // colorized `óra` string

--- a/tests/test-table.php
+++ b/tests/test-table.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Tests for cli\Table
  */
@@ -35,4 +34,22 @@ class Test_Table extends PHPUnit_Framework_TestCase {
 
 	}
 
+	public function test_column_value_too_long_with_multibytes() {
+
+		$constraint_width = 80;
+
+		$table = new cli\Table;
+		$renderer = new cli\Table\Ascii;
+		$renderer->setConstraintWidth( $constraint_width );
+		$table->setRenderer( $renderer );
+		$table->setHeaders( array( 'Field', 'Value' ) );
+		$table->addRow( array( 'この文章はダミーです。文字の大きさ、量、字間、行間等を確認するために入れています。この文章はダミーです。文字の大きさ、量、字間、行間等を確認するために入れています。この文章はダミーです。文字の大きさ、', 'こんにちは' ) );
+		$table->addRow( array( 'Lorem Ipsum is simply dummy text of the printing and typesetting industry.', 'Hello' ) );
+
+		$out = $table->getDisplayLines();
+
+		for ( $i = 0; $i < count( $out ); $i++ ) {
+			$this->assertEquals( $constraint_width, mb_strwidth( $out[$i] ) + 1 );
+		}
+	}
 }

--- a/tests/test-table.php
+++ b/tests/test-table.php
@@ -47,7 +47,7 @@ class Test_Table extends PHPUnit_Framework_TestCase {
 		$table->addRow( array( 'Lorem Ipsum is simply dummy text of the printing and typesetting industry.', 'Hello' ) );
 
 		$out = $table->getDisplayLines();
-
+		print_r( $out );
 		for ( $i = 0; $i < count( $out ); $i++ ) {
 			$this->assertEquals( $constraint_width, mb_strwidth( $out[$i] ) + 1 );
 		}


### PR DESCRIPTION
Incorrect table column width with multibyte text.
I added a test for this problem so it will be failed.

The output is like following.

```
array(8) {
  [0]=>
  string(79) "+----------------------------------------------------------------+------------+"
  [1]=>
  string(79) "| Field                                                          | Value      |"
  [2]=>
  string(79) "+----------------------------------------------------------------+------------+"
  [3]=>
  string(208) "| この文章はダミーです。文字の大きさ、量、字間、行間等を確認するために入れています。この文章はダミーです。文字の大きさ、量、字 | こんにちは |"
  [4]=>
  string(131) "| 間、行間等を確認するために入れています。この文章はダミーです。文字の大きさ、 |            |"
  [5]=>
  string(79) "| Lorem Ipsum is simply dummy text of the printing and typesetti | Hello      |"
  [6]=>
  string(79) "| ng industry.                                                   |            |"
  [7]=>
  string(79) "+----------------------------------------------------------------+------------+"
}
```

I am trying to fix this problem, but I haven't find a cause for now.
Are there any hints?