### PR TITLE
PR 109 (double-width wrapping) and issue 106 (pre-colorization).

### DIFF
--- a/lib/cli/Colors.php
+++ b/lib/cli/Colors.php
@@ -146,7 +146,7 @@ class Colors {
 	 * @param bool   $keep_tokens Optional. If set, color tokens (eg "%n") won't be stripped. Default false.
 	 * @return string A string with color information removed.
 	 */
-	static public function decolorize( $string, bool $keep_tokens = false ) {
+	static public function decolorize( $string, $keep_tokens = false ) {
 		if ( ! $keep_tokens ) {
 			// Get rid of color tokens if they exist
 			$string = str_replace('%%', '%¾', $string);

--- a/lib/cli/Colors.php
+++ b/lib/cli/Colors.php
@@ -194,7 +194,7 @@ class Colors {
 	 * @param bool   $pre_colorized Optional. Set if the string is pre-colorized. Default false.
      * @return int
 	 */
-	static public function width( $string, bool $pre_colorized = false ) {
+	static public function width( $string, $pre_colorized = false ) {
 		return strwidth( $pre_colorized || self::shouldColorize() ? self::decolorize( $string, $pre_colorized /*keep_tokens*/ ) : $string );
 	}
 
@@ -206,7 +206,7 @@ class Colors {
 	 * @param bool   $pre_colorized Optional. Set if the string is pre-colorized. Default false.
      * @return string
 	 */
-	static public function pad( $string, $length, bool $pre_colorized = false ) {
+	static public function pad( $string, $length, $pre_colorized = false ) {
 		$real_length = self::width( $string, $pre_colorized );
 		$diff = strlen( $string ) - $real_length;
 		$length += $diff;

--- a/lib/cli/Table.php
+++ b/lib/cli/Table.php
@@ -102,7 +102,7 @@ class Table {
 	 */
 	protected function checkRow(array $row) {
 		foreach ($row as $column => $str) {
-			$width = Colors::shouldColorize() ? Colors::width($str) : strwidth($str);
+			$width = Colors::width( $str, $this->isAsciiPreColorized( $column ) );
 			if (!isset($this->_width[$column]) || $width > $this->_width[$column]) {
 				$this->_width[$column] = $width;
 			}
@@ -227,5 +227,31 @@ class Table {
 
 	public function countRows() {
 		return count($this->_rows);
+	}
+
+	/**
+	 * Set whether items in an Ascii table are pre-colorized.
+	 *
+	 * @param bool|array $precolorized A boolean to set all columns in the table as pre-colorized, or an array of booleans keyed by column index (number) to set individual columns as pre-colorized.
+	 * @see cli\Ascii::setPreColorized()
+	 */
+	public function setAsciiPreColorized( $pre_colorized ) {
+		if ( $this->_renderer instanceof Ascii ) {
+			$this->_renderer->setPreColorized( $pre_colorized );
+		}
+	}
+
+	/**
+	 * Is a column in an Ascii table pre-colorized?
+	 *
+	 * @param int $column Column index to check.
+	 * @return bool True if whole Ascii table is marked as pre-colorized, or if the individual column is pre-colorized; else false.
+	 * @see cli\Ascii::isPreColorized()
+	 */
+	private function isAsciiPreColorized( int $column ) {
+		if ( $this->_renderer instanceof Ascii ) {
+			return $this->_renderer->isPreColorized( $column );
+		}
+		return false;
 	}
 }

--- a/lib/cli/Table.php
+++ b/lib/cli/Table.php
@@ -248,7 +248,7 @@ class Table {
 	 * @return bool True if whole Ascii table is marked as pre-colorized, or if the individual column is pre-colorized; else false.
 	 * @see cli\Ascii::isPreColorized()
 	 */
-	private function isAsciiPreColorized( int $column ) {
+	private function isAsciiPreColorized( $column ) {
 		if ( $this->_renderer instanceof Ascii ) {
 			return $this->_renderer->isPreColorized( $column );
 		}

--- a/lib/cli/table/Ascii.php
+++ b/lib/cli/table/Ascii.php
@@ -134,17 +134,18 @@ class Ascii extends Renderer {
 				$value = str_replace( PHP_EOL, ' ', $value );
 
 				$col_width = $this->_widths[ $col ];
-				$original_val_width = Colors::width( $value, self::isPreColorized( $col ) );
+				$encoding = function_exists( 'mb_detect_encoding' ) ? mb_detect_encoding( $value, null, true /*strict*/ ) : false;
+				$original_val_width = Colors::width( $value, self::isPreColorized( $col ), $encoding );
 				if ( $original_val_width > $col_width ) {
-					$row[ $col ] = \cli\safe_substr( $value, 0, $col_width, true /*width*/ );
-					$value = \cli\safe_substr( $value, \cli\safe_strlen( $row[ $col ] ), null );
+					$row[ $col ] = \cli\safe_substr( $value, 0, $col_width, true /*is_width*/, $encoding );
+					$value = \cli\safe_substr( $value, \cli\safe_strlen( $row[ $col ], $encoding ), null /*length*/, false /*is_width*/, $encoding );
 					$i = 0;
 					do {
-						$extra_value = \cli\safe_substr( $value, 0, $col_width, true /*width*/ );
-						$val_width = Colors::width( $extra_value, self::isPreColorized( $col ) );
+						$extra_value = \cli\safe_substr( $value, 0, $col_width, true /*is_width*/, $encoding );
+						$val_width = Colors::width( $extra_value, self::isPreColorized( $col ), $encoding );
 						if ( $val_width ) {
 							$extra_rows[ $col ][] = $extra_value;
-							$value = \cli\safe_substr( $value, \cli\safe_strlen( $extra_value ), null );
+							$value = \cli\safe_substr( $value, \cli\safe_strlen( $extra_value, $encoding ), null /*length*/, false /*is_width*/, $encoding );
 							$i++;
 							if ( $i > $extra_row_count ) {
 								$extra_row_count = $i;

--- a/lib/cli/table/Ascii.php
+++ b/lib/cli/table/Ascii.php
@@ -207,7 +207,7 @@ class Ascii extends Renderer {
 	 * @param int $column Column index to check.
 	 * @return bool True if whole table is marked as pre-colorized, or if the individual column is pre-colorized; else false.
 	 */
-	public function isPreColorized( int $column ) {
+	public function isPreColorized( $column ) {
 		if ( is_bool( $this->_pre_colorized ) ) {
 			return $this->_pre_colorized;
 		}

--- a/lib/cli/table/Ascii.php
+++ b/lib/cli/table/Ascii.php
@@ -27,6 +27,7 @@ class Ascii extends Renderer {
 	);
 	protected $_border = null;
 	protected $_constraintWidth = null;
+	protected $_pre_colorized = false;
 
 	/**
 	 * Set the widths of each column in the table.
@@ -133,17 +134,17 @@ class Ascii extends Renderer {
 				$value = str_replace( PHP_EOL, ' ', $value );
 
 				$col_width = $this->_widths[ $col ];
-				$original_val_width = Colors::shouldColorize() ? Colors::width( $value ) : \cli\strwidth( $value );
+				$original_val_width = Colors::width( $value, self::isPreColorized( $col ) );
 				if ( $original_val_width > $col_width ) {
-					$row[ $col ] = \cli\safe_substr( $value, 0, $col_width );
-					$value = \cli\safe_substr( $value, $col_width, $original_val_width );
+					$row[ $col ] = \cli\safe_substr( $value, 0, $col_width, true /*width*/ );
+					$value = \cli\safe_substr( $value, \cli\safe_strlen( $row[ $col ] ), null );
 					$i = 0;
 					do {
-						$extra_value = \cli\safe_substr( $value, 0, $col_width );
-						$val_width = \cli\strwidth( $extra_value );
+						$extra_value = \cli\safe_substr( $value, 0, $col_width, true /*width*/ );
+						$val_width = Colors::width( $extra_value, self::isPreColorized( $col ) );
 						if ( $val_width ) {
 							$extra_rows[ $col ][] = $extra_value;
-							$value = \cli\safe_substr( $value, $col_width, $original_val_width );
+							$value = \cli\safe_substr( $value, \cli\safe_strlen( $extra_value ), null );
 							$i++;
 							if ( $i > $extra_row_count ) {
 								$extra_row_count = $i;
@@ -188,6 +189,31 @@ class Ascii extends Renderer {
 	}
 
 	private function padColumn($content, $column) {
-		return $this->_characters['padding'] . Colors::pad($content, $this->_widths[$column]) . $this->_characters['padding'];
+		return $this->_characters['padding'] . Colors::pad( $content, $this->_widths[ $column ], $this->isPreColorized( $column ) ) . $this->_characters['padding'];
+	}
+
+	/**
+	 * Set whether items are pre-colorized.
+	 *
+	 * @param bool|array $colorized A boolean to set all columns in the table as pre-colorized, or an array of booleans keyed by column index (number) to set individual columns as pre-colorized.
+	 */
+	public function setPreColorized( $pre_colorized ) {
+		$this->_pre_colorized = $pre_colorized;
+	}
+
+	/**
+	 * Is a column pre-colorized?
+	 *
+	 * @param int $column Column index to check.
+	 * @return bool True if whole table is marked as pre-colorized, or if the individual column is pre-colorized; else false.
+	 */
+	public function isPreColorized( int $column ) {
+		if ( is_bool( $this->_pre_colorized ) ) {
+			return $this->_pre_colorized;
+		}
+		if ( is_array( $this->_pre_colorized ) && isset( $this->_pre_colorized[ $column ] ) ) {
+			return $this->_pre_colorized[ $column ];
+		}
+		return false;
 	}
 }

--- a/tests/test-cli.php
+++ b/tests/test-cli.php
@@ -45,8 +45,30 @@ class testsCli extends PHPUnit_Framework_TestCase {
 	}
 
 	function test_colorized_string_pad() {
-		$this->assertEquals( 22, strlen( \cli\Colors::pad( \cli\Colors::colorize( "%Gx%n", true ), 11 ))); // colorized `x` string
-		$this->assertEquals( 23, strlen( \cli\Colors::pad( \cli\Colors::colorize( "%Góra%n", true ), 11 ))); // colorized `óra` string
+		// Colors enabled.
+
+		$colorized = \cli\Colors::colorize( '%Gx%n', true ); // colorized `x` string
+		$this->assertSame( 22, strlen( \cli\Colors::pad( $colorized, 11 ) ) );
+		$this->assertSame( 22, strlen( \cli\Colors::pad( $colorized, 11, false /*pre_colorized*/ ) ) );
+		$this->assertSame( 22, strlen( \cli\Colors::pad( $colorized, 11, true /*pre_colorized*/ ) ) );
+
+		$colorized = \cli\Colors::colorize( "%Góra%n", true ); // colorized `óra` string
+		$this->assertSame( 23, strlen( \cli\Colors::pad( $colorized, 11 ) ) );
+		$this->assertSame( 23, strlen( \cli\Colors::pad( $colorized, 11, false /*pre_colorized*/ ) ) );
+		$this->assertSame( 23, strlen( \cli\Colors::pad( $colorized, 11, true /*pre_colorized*/ ) ) );
+
+		// Colors disabled.
+		\cli\Colors::disable( true );
+
+		$colorized = \cli\Colors::colorize( '%Gx%n', true ); // colorized `x` string
+		$this->assertSame( 12, strlen( \cli\Colors::pad( $colorized, 12 ) ) );
+		$this->assertSame( 12, strlen( \cli\Colors::pad( $colorized, 12, false /*pre_colorized*/ ) ) );
+		$this->assertSame( 23, strlen( \cli\Colors::pad( $colorized, 12, true /*pre_colorized*/ ) ) );
+
+		$colorized = \cli\Colors::colorize( "%Góra%n", true ); // colorized `óra` string
+		$this->assertSame( 16, strlen( \cli\Colors::pad( $colorized, 15 ) ) );
+		$this->assertSame( 16, strlen( \cli\Colors::pad( $colorized, 15, false /*pre_colorized*/ ) ) );
+		$this->assertSame( 27, strlen( \cli\Colors::pad( $colorized, 15, true /*pre_colorized*/ ) ) );
 	}
 
 	function test_encoded_substr() {
@@ -63,8 +85,30 @@ class testsCli extends PHPUnit_Framework_TestCase {
 	}
 
 	function test_colorized_string_width() {
-		$this->assertEquals( \cli\Colors::width( \cli\Colors::colorize( '%Gx%n', true ) ), 1 );
-		$this->assertEquals( \cli\Colors::width( \cli\Colors::colorize( '%G日%n', true ) ), 2 ); // Double-width char.
+		// Colors enabled.
+
+		$colorized = \cli\Colors::colorize( '%Gx%n', true );
+		$this->assertSame( 1, \cli\Colors::width( $colorized ) );
+		$this->assertSame( 1, \cli\Colors::width( $colorized, false /*pre_colorized*/ ) );
+		$this->assertSame( 1, \cli\Colors::width( $colorized, true /*pre_colorized*/ ) );
+
+		$colorized = \cli\Colors::colorize( '%G日%n', true ); // Double-width char.
+		$this->assertSame( 2, \cli\Colors::width( $colorized ) );
+		$this->assertSame( 2, \cli\Colors::width( $colorized, false /*pre_colorized*/ ) );
+		$this->assertSame( 2, \cli\Colors::width( $colorized, true /*pre_colorized*/ ) );
+
+		// Colors disabled.
+		\cli\Colors::disable( true );
+
+		$colorized = \cli\Colors::colorize( '%Gx%n', true );
+		$this->assertSame( 12, \cli\Colors::width( $colorized ) );
+		$this->assertSame( 12, \cli\Colors::width( $colorized, false /*pre_colorized*/ ) );
+		$this->assertSame( 1, \cli\Colors::width( $colorized, true /*pre_colorized*/ ) );
+
+		$colorized = \cli\Colors::colorize( '%G日%n', true ); // Double-width char.
+		$this->assertSame( 13, \cli\Colors::width( $colorized ) );
+		$this->assertSame( 13, \cli\Colors::width( $colorized, false /*pre_colorized*/ ) );
+		$this->assertSame( 2, \cli\Colors::width( $colorized, true /*pre_colorized*/ ) );
 	}
 
 	function test_colorize_string_is_colored() {

--- a/tests/test-cli.php
+++ b/tests/test-cli.php
@@ -1,5 +1,7 @@
 <?php
 
+use cli\Colors;
+
 class testsCli extends PHPUnit_Framework_TestCase {
 
 	function setUp() {
@@ -46,30 +48,30 @@ class testsCli extends PHPUnit_Framework_TestCase {
 
 	function test_colorized_string_pad() {
 		// Colors enabled.
-		\cli\Colors::enable( true );
+		Colors::enable( true );
 
-		$colorized = \cli\Colors::colorize( '%Gx%n', true ); // colorized `x` string
-		$this->assertSame( 22, strlen( \cli\Colors::pad( $colorized, 11 ) ) );
-		$this->assertSame( 22, strlen( \cli\Colors::pad( $colorized, 11, false /*pre_colorized*/ ) ) );
-		$this->assertSame( 22, strlen( \cli\Colors::pad( $colorized, 11, true /*pre_colorized*/ ) ) );
+		$x = Colors::colorize( '%Gx%n', true ); // colorized `x` string
+		$ora = Colors::colorize( "%Góra%n", true ); // colorized `óra` string
 
-		$colorized = \cli\Colors::colorize( "%Góra%n", true ); // colorized `óra` string
-		$this->assertSame( 23, strlen( \cli\Colors::pad( $colorized, 11 ) ) );
-		$this->assertSame( 23, strlen( \cli\Colors::pad( $colorized, 11, false /*pre_colorized*/ ) ) );
-		$this->assertSame( 23, strlen( \cli\Colors::pad( $colorized, 11, true /*pre_colorized*/ ) ) );
+		$this->assertSame( 22, strlen( Colors::pad( $x, 11 ) ) );
+		$this->assertSame( 22, strlen( Colors::pad( $x, 11, false /*pre_colorized*/ ) ) );
+		$this->assertSame( 22, strlen( Colors::pad( $x, 11, true /*pre_colorized*/ ) ) );
+
+		$this->assertSame( 23, strlen( Colors::pad( $ora, 11 ) ) ); // +1 for two-byte "ó".
+		$this->assertSame( 23, strlen( Colors::pad( $ora, 11, false /*pre_colorized*/ ) ) );
+		$this->assertSame( 23, strlen( Colors::pad( $ora, 11, true /*pre_colorized*/ ) ) );
 
 		// Colors disabled.
-		\cli\Colors::disable( true );
+		Colors::disable( true );
+		$this->assertFalse( Colors::shouldColorize() );
 
-		$colorized = \cli\Colors::colorize( '%Gx%n', true ); // colorized `x` string
-		$this->assertSame( 12, strlen( \cli\Colors::pad( $colorized, 12 ) ) );
-		$this->assertSame( 12, strlen( \cli\Colors::pad( $colorized, 12, false /*pre_colorized*/ ) ) );
-		$this->assertSame( 23, strlen( \cli\Colors::pad( $colorized, 12, true /*pre_colorized*/ ) ) );
+		$this->assertSame( 20, strlen( Colors::pad( $x, 20 ) ) );
+		$this->assertSame( 20, strlen( Colors::pad( $x, 20, false /*pre_colorized*/ ) ) );
+		$this->assertSame( 31, strlen( Colors::pad( $x, 20, true /*pre_colorized*/ ) ) );
 
-		$colorized = \cli\Colors::colorize( "%Góra%n", true ); // colorized `óra` string
-		$this->assertSame( 16, strlen( \cli\Colors::pad( $colorized, 15 ) ) );
-		$this->assertSame( 16, strlen( \cli\Colors::pad( $colorized, 15, false /*pre_colorized*/ ) ) );
-		$this->assertSame( 27, strlen( \cli\Colors::pad( $colorized, 15, true /*pre_colorized*/ ) ) );
+		$this->assertSame( 21, strlen( Colors::pad( $ora, 20 ) ) ); // +1 for two-byte "ó".
+		$this->assertSame( 21, strlen( Colors::pad( $ora, 20, false /*pre_colorized*/ ) ) );
+		$this->assertSame( 32, strlen( Colors::pad( $ora, 20, true /*pre_colorized*/ ) ) );
 	}
 
 	function test_encoded_substr() {
@@ -78,6 +80,57 @@ class testsCli extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( \cli\safe_substr( \cli\Colors::pad( 'óra', 6), 0, 2 ), 'ór'  );
 		$this->assertEquals( \cli\safe_substr( \cli\Colors::pad( '日本語', 6), 0, 2 ), '日本'  );
 
+		$this->assertSame( 'el', \cli\safe_substr( Colors::pad( 'hello', 6 ), 1, 2 ) );
+
+		$this->assertSame( 'a ', \cli\safe_substr( Colors::pad( 'óra', 6 ), 2, 2 ) );
+		$this->assertSame( ' ', \cli\safe_substr( Colors::pad( 'óra', 6 ), 5, 2 ) );
+
+		$this->assertSame( '本語', \cli\safe_substr( Colors::pad( '日本語', 8 ), 1, 2 ) );
+		$this->assertSame( '語 ', \cli\safe_substr( Colors::pad( '日本語', 8 ), 2, 2 ) );
+
+	}
+
+	function test_encoded_substr_is_width() {
+
+		$this->assertSame( 'he',  \cli\safe_substr( Colors::pad( 'hello', 6 ), 0, 2, true /*is_width*/ ) );
+		$this->assertSame( 'ór', \cli\safe_substr( Colors::pad( 'óra', 6 ), 0, 2, true /*is_width*/ ) );
+		$this->assertSame( '日', \cli\safe_substr( Colors::pad( '日本語', 8 ), 0, 2, true /*is_width*/ ) );
+		$this->assertSame( '日本', \cli\safe_substr( Colors::pad( '日本語', 8 ), 0, 4, true /*is_width*/ ) );
+		$this->assertSame( '日本', \cli\safe_substr( Colors::pad( '日本語', 8 ), 0, 3, true /*is_width*/ ) );
+		$this->assertSame( '日本語', \cli\safe_substr( Colors::pad( '日本語', 8 ), 0, 6, true /*is_width*/ ) );
+		$this->assertSame( '日本語 ', \cli\safe_substr( Colors::pad( '日本語', 8 ), 0, 7, true /*is_width*/ ) );
+
+		$this->assertSame( 'el', \cli\safe_substr( Colors::pad( 'hello', 6 ), 1, 2, true /*is_width*/ ) );
+
+		$this->assertSame( 'a ', \cli\safe_substr( Colors::pad( 'óra', 6 ), 2, 2, true /*is_width*/ ) );
+		$this->assertSame( ' ', \cli\safe_substr( Colors::pad( 'óra', 6 ), 5, 2, true /*is_width*/ ) );
+
+		$this->assertSame( '', \cli\safe_substr( '1日4本語90', 0, 0, true /*is_width*/ ) );
+		$this->assertSame( '1', \cli\safe_substr( '1日4本語90', 0, 1, true /*is_width*/ ) );
+		$this->assertSame( '1日', \cli\safe_substr( '1日4本語90', 0, 2, true /*is_width*/ ) );
+		$this->assertSame( '1日', \cli\safe_substr( '1日4本語90', 0, 3, true /*is_width*/ ) );
+		$this->assertSame( '1日4', \cli\safe_substr( '1日4本語90', 0, 4, true /*is_width*/ ) );
+		$this->assertSame( '1日4本', \cli\safe_substr( '1日4本語90', 0, 5, true /*is_width*/ ) );
+		$this->assertSame( '1日4本', \cli\safe_substr( '1日4本語90', 0, 6, true /*is_width*/ ) );
+		$this->assertSame( '1日4本語', \cli\safe_substr( '1日4本語90', 0, 7, true /*is_width*/ ) );
+		$this->assertSame( '1日4本語', \cli\safe_substr( '1日4本語90', 0, 8, true /*is_width*/ ) );
+		$this->assertSame( '1日4本語9', \cli\safe_substr( '1日4本語90', 0, 9, true /*is_width*/ ) );
+		$this->assertSame( '1日4本語90', \cli\safe_substr( '1日4本語90', 0, 10, true /*is_width*/ ) );
+		$this->assertSame( '1日4本語90', \cli\safe_substr( '1日4本語90', 0, 11, true /*is_width*/ ) );
+
+		$this->assertSame( '日', \cli\safe_substr( '1日4本語90', 1, 2, true /*is_width*/ ) );
+		$this->assertSame( '日4', \cli\safe_substr( '1日4本語90', 1, 3, true /*is_width*/ ) );
+		$this->assertSame( '4本語9', \cli\safe_substr( '1日4本語90', 2, 6, true /*is_width*/ ) );
+
+		$this->assertSame( '本', \cli\safe_substr( '1日4本語90', 3, 1, true /*is_width*/ ) );
+		$this->assertSame( '本', \cli\safe_substr( '1日4本語90', 3, 2, true /*is_width*/ ) );
+		$this->assertSame( '本語', \cli\safe_substr( '1日4本語90', 3, 3, true /*is_width*/ ) );
+		$this->assertSame( '本語', \cli\safe_substr( '1日4本語90', 3, 4, true /*is_width*/ ) );
+		$this->assertSame( '本語9', \cli\safe_substr( '1日4本語90', 3, 5, true /*is_width*/ ) );
+
+		$this->assertSame( '0', \cli\safe_substr( '1日4本語90', 6, 1, true /*is_width*/ ) );
+		$this->assertSame( '', \cli\safe_substr( '1日4本語90', 7, 1, true /*is_width*/ ) );
+		$this->assertSame( '', \cli\safe_substr( '1日4本語90', 6, 0, true /*is_width*/ ) );
 	}
 
 	function test_colorized_string_length() {
@@ -87,30 +140,30 @@ class testsCli extends PHPUnit_Framework_TestCase {
 
 	function test_colorized_string_width() {
 		// Colors enabled.
-		\cli\Colors::enable( true );
+		Colors::enable( true );
 
-		$colorized = \cli\Colors::colorize( '%Gx%n', true );
-		$this->assertSame( 1, \cli\Colors::width( $colorized ) );
-		$this->assertSame( 1, \cli\Colors::width( $colorized, false /*pre_colorized*/ ) );
-		$this->assertSame( 1, \cli\Colors::width( $colorized, true /*pre_colorized*/ ) );
+		$x = Colors::colorize( '%Gx%n', true );
+		$dw = Colors::colorize( '%G日%n', true ); // Double-width char.
 
-		$colorized = \cli\Colors::colorize( '%G日%n', true ); // Double-width char.
-		$this->assertSame( 2, \cli\Colors::width( $colorized ) );
-		$this->assertSame( 2, \cli\Colors::width( $colorized, false /*pre_colorized*/ ) );
-		$this->assertSame( 2, \cli\Colors::width( $colorized, true /*pre_colorized*/ ) );
+		$this->assertSame( 1, Colors::width( $x ) );
+		$this->assertSame( 1, Colors::width( $x, false /*pre_colorized*/ ) );
+		$this->assertSame( 1, Colors::width( $x, true /*pre_colorized*/ ) );
+
+		$this->assertSame( 2, Colors::width( $dw ) );
+		$this->assertSame( 2, Colors::width( $dw, false /*pre_colorized*/ ) );
+		$this->assertSame( 2, Colors::width( $dw, true /*pre_colorized*/ ) );
 
 		// Colors disabled.
-		\cli\Colors::disable( true );
+		Colors::disable( true );
+		$this->assertFalse( Colors::shouldColorize() );
 
-		$colorized = \cli\Colors::colorize( '%Gx%n', true );
-		$this->assertSame( 12, \cli\Colors::width( $colorized ) );
-		$this->assertSame( 12, \cli\Colors::width( $colorized, false /*pre_colorized*/ ) );
-		$this->assertSame( 1, \cli\Colors::width( $colorized, true /*pre_colorized*/ ) );
+		$this->assertSame( 12, Colors::width( $x ) );
+		$this->assertSame( 12, Colors::width( $x, false /*pre_colorized*/ ) );
+		$this->assertSame( 1, Colors::width( $x, true /*pre_colorized*/ ) );
 
-		$colorized = \cli\Colors::colorize( '%G日%n', true ); // Double-width char.
-		$this->assertSame( 13, \cli\Colors::width( $colorized ) );
-		$this->assertSame( 13, \cli\Colors::width( $colorized, false /*pre_colorized*/ ) );
-		$this->assertSame( 2, \cli\Colors::width( $colorized, true /*pre_colorized*/ ) );
+		$this->assertSame( 13, Colors::width( $dw ) );
+		$this->assertSame( 13, Colors::width( $dw, false /*pre_colorized*/ ) );
+		$this->assertSame( 2, Colors::width( $dw, true /*pre_colorized*/ ) );
 	}
 
 	function test_colorize_string_is_colored() {
@@ -160,6 +213,58 @@ class testsCli extends PHPUnit_Framework_TestCase {
 
 		// Test that the cache value is correctly set
 		$this->assertEquals( $test_cache, $real_cache[ md5( $string_with_color ) ] );
+	}
+
+	function test_string_cache_colorize() {
+		$string            = 'x';
+		$string_with_color = '%k' . $string;
+		$colorized_string  = "\033[30m$string";
+
+		// Colors enabled.
+		Colors::enable( true );
+
+		// Ensure colorization works
+		$this->assertSame( $colorized_string, Colors::colorize( $string_with_color ) );
+		$this->assertSame( $colorized_string, Colors::colorize( $string_with_color ) );
+
+		// Colors disabled.
+		Colors::disable( true );
+		$this->assertFalse( Colors::shouldColorize() );
+
+		// Ensure it doesn't come from the cache.
+		$this->assertSame( $string, Colors::colorize( $string_with_color ) );
+		$this->assertSame( $string, Colors::colorize( $string_with_color ) );
+
+		// Check that escaped % isn't stripped on putting into cache.
+		$string = 'x%%n';
+		$string_with_color = '%k' . $string;
+		$this->assertSame( 'x%n', Colors::colorize( $string_with_color ) );
+		$this->assertSame( 'x%n', Colors::colorize( $string_with_color ) );
+	}
+
+	function test_decolorize() {
+		// Colors enabled.
+		Colors::enable( true );
+
+		$string = '%kx%%n%n';
+		$colorized_string = Colors::colorize( $string );
+		$both_string = '%gfoo' . $colorized_string . 'bar%%%n';
+
+		$this->assertSame( 'x%n', Colors::decolorize( $string ) );
+		$this->assertSame( 'x', Colors::decolorize( $colorized_string ) );
+		$this->assertSame( 'fooxbar%', Colors::decolorize( $both_string ) );
+
+		$this->assertSame( $string, Colors::decolorize( $string, 1 /*keep_tokens*/ ) );
+		$this->assertSame( 'x%n', Colors::decolorize( $colorized_string, 1 /*keep_tokens*/ ) );
+		$this->assertSame( '%gfoox%nbar%%%n', Colors::decolorize( $both_string, 1 /*keep_tokens*/ ) );
+
+		$this->assertSame( 'x%n', Colors::decolorize( $string, 2 /*keep_encodings*/ ) );
+		$this->assertSame( '[30mx[0m', Colors::decolorize( $colorized_string, 2 /*keep_encodings*/ ) );
+		$this->assertSame( 'foo[30mx[0mbar%', Colors::decolorize( $both_string, 2 /*keep_encodings*/ ) );
+
+		$this->assertSame( $string, Colors::decolorize( $string, 3 /*noop*/ ) );
+		$this->assertSame( $colorized_string, Colors::decolorize( $colorized_string, 3 /*noop*/ ) );
+		$this->assertSame( $both_string, Colors::decolorize( $both_string, 3 /*noop*/ ) );
 	}
 
 	function test_strwidth() {

--- a/tests/test-cli.php
+++ b/tests/test-cli.php
@@ -46,6 +46,7 @@ class testsCli extends PHPUnit_Framework_TestCase {
 
 	function test_colorized_string_pad() {
 		// Colors enabled.
+		\cli\Colors::enable( true );
 
 		$colorized = \cli\Colors::colorize( '%Gx%n', true ); // colorized `x` string
 		$this->assertSame( 22, strlen( \cli\Colors::pad( $colorized, 11 ) ) );
@@ -86,6 +87,7 @@ class testsCli extends PHPUnit_Framework_TestCase {
 
 	function test_colorized_string_width() {
 		// Colors enabled.
+		\cli\Colors::enable( true );
 
 		$colorized = \cli\Colors::colorize( '%Gx%n', true );
 		$this->assertSame( 1, \cli\Colors::width( $colorized ) );

--- a/tests/test-table.php
+++ b/tests/test-table.php
@@ -1,5 +1,7 @@
 <?php
 
+use cli\Colors, cli\Table, cli\Table\Ascii;
+
 /**
  * Tests for cli\Table
  */
@@ -33,6 +35,94 @@ class Test_Table extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( $constraint_width, strlen( $out[10] ) + 1 );
 		$this->assertEquals( $constraint_width, strlen( $out[11] ) + 1 );
 
+	}
+
+	public function test_column_value_too_long_with_multibytes() {
+
+		$constraint_width = 80;
+
+		$table = new cli\Table;
+		$renderer = new cli\Table\Ascii;
+		$renderer->setConstraintWidth( $constraint_width );
+		$table->setRenderer( $renderer );
+		$table->setHeaders( array( 'Field', 'Value' ) );
+		$table->addRow( array( 'この文章はダミーです。文字の大きさ、量、字間、行間等を確認するために入れています。この文章はダミーです。文字の大きさ、量、字間、行間等を確認するために入れています。この文章はダミーです。文字の大きさ、', 'こんにちは' ) );
+		$table->addRow( array( 'Lorem Ipsum is simply dummy text of the printing and typesetting industry.', 'Hello' ) );
+
+		$out = $table->getDisplayLines();
+		print_r( $out );
+		for ( $i = 0; $i < count( $out ); $i++ ) {
+			$this->assertEquals( $constraint_width, mb_strwidth( $out[$i] ) + 1 );
+		}
+	}
+
+	public function test_ascii_pre_colorized_widths() {
+
+		Colors::enable( true );
+
+		$headers = array( 'package', 'version', 'result' );
+		$items = array(
+			array( Colors::colorize( '%ygaa/gaa-kabes%n' ), 'dev-master', Colors::colorize( "%rx%n" ) ),
+			array( Colors::colorize( '%ygaa/gaa-log%n' ), '*', Colors::colorize( "%gok%n" ) ),
+			array( Colors::colorize( '%ygaa/gaa-nonsense%n' ), 'v3.0.11', Colors::colorize( "%rx%n" ) ),
+			array( Colors::colorize( '%ygaa/gaa-100%%new%n' ), 'v100%new', Colors::colorize( "%gok%n" ) ),
+		);
+
+		// Disable colorization, as `\WP_CLI\Formatter::show_table()` does for Ascii tables.
+		Colors::disable( true );
+		$this->assertFalse( Colors::shouldColorize() );
+
+		// Account for colorization of columns 0 & 2.
+
+		$table = new Table;
+		$renderer = new Ascii;
+		$table->setRenderer( $renderer );
+		$table->setAsciiPreColorized( array( true, false, true ) );
+		$table->setHeaders( $headers );
+		$table->setRows( $items );
+
+		$out = $table->getDisplayLines();
+		error_log( "out=" . print_r( $out, true ) );
+
+		// "+ 4" accommodates 3 borders and header.
+		$this->assertSame( 4 + 4, count( $out ) );
+
+		// Borders & header.
+		$this->assertSame( 42, strlen( $out[0] ) );
+		$this->assertSame( 42, strlen( $out[1] ) );
+		$this->assertSame( 42, strlen( $out[2] ) );
+		$this->assertSame( 42, strlen( $out[7] ) );
+
+		// Data.
+		$this->assertSame( 60, strlen( $out[3] ) );
+		$this->assertSame( 60, strlen( $out[4] ) );
+		$this->assertSame( 60, strlen( $out[5] ) );
+		$this->assertSame( 60, strlen( $out[6] ) );
+
+		// Don't account for colorization of columns 0 & 2.
+
+		$table = new Table;
+		$renderer = new Ascii;
+		$table->setRenderer( $renderer );
+		$table->setHeaders( $headers );
+		$table->setRows( $items );
+
+		$out = $table->getDisplayLines();
+
+		// "+ 4" accommodates 3 borders and header.
+		$this->assertSame( 4 + 4, count( $out ) );
+
+		// Borders & header.
+		$this->assertSame( 56, strlen( $out[0] ) );
+		$this->assertSame( 56, strlen( $out[1] ) );
+		$this->assertSame( 56, strlen( $out[2] ) );
+		$this->assertSame( 56, strlen( $out[7] ) );
+
+		// Data.
+		$this->assertSame( 56, strlen( $out[3] ) );
+		$this->assertSame( 56, strlen( $out[4] ) );
+		$this->assertSame( 56, strlen( $out[5] ) );
+		$this->assertSame( 56, strlen( $out[6] ) );
 	}
 
 }

--- a/tests/test-table.php
+++ b/tests/test-table.php
@@ -52,7 +52,7 @@ class Test_Table extends PHPUnit_Framework_TestCase {
 		$out = $table->getDisplayLines();
 		print_r( $out );
 		for ( $i = 0; $i < count( $out ); $i++ ) {
-			$this->assertEquals( $constraint_width, mb_strwidth( $out[$i] ) + 1 );
+			$this->assertEquals( $constraint_width, \cli\strwidth( $out[$i] ) + 1 );
 		}
 	}
 

--- a/tests/test-table.php
+++ b/tests/test-table.php
@@ -50,7 +50,6 @@ class Test_Table extends PHPUnit_Framework_TestCase {
 		$table->addRow( array( 'Lorem Ipsum is simply dummy text of the printing and typesetting industry.', 'Hello' ) );
 
 		$out = $table->getDisplayLines();
-		print_r( $out );
 		for ( $i = 0; $i < count( $out ); $i++ ) {
 			$this->assertEquals( $constraint_width, \cli\strwidth( $out[$i] ) + 1 );
 		}

--- a/tests/test-table.php
+++ b/tests/test-table.php
@@ -82,7 +82,6 @@ class Test_Table extends PHPUnit_Framework_TestCase {
 		$table->setRows( $items );
 
 		$out = $table->getDisplayLines();
-		error_log( "out=" . print_r( $out, true ) );
 
 		// "+ 4" accommodates 3 borders and header.
 		$this->assertSame( 4 + 4, count( $out ) );


### PR DESCRIPTION
PR https://github.com/wp-cli/php-cli-tools/pull/109 and issue https://github.com/wp-cli/php-cli-tools/issues/106

For PR https://github.com/wp-cli/php-cli-tools/pull/109 (incorrect wrapping of East Asian double-width chars in tables), adds an `is_width` arg to `safe_substr()` to make it interpret the `length` arg as a spacing width, and uses the East Asian Width regex (now refactored to load in a function) to adjust accordingly (a slow algorithm but couldn't think of anything better). Uses this in `Ascii::row()`.

For issue https://github.com/wp-cli/php-cli-tools/issues/106 (related https://github.com/wp-cli/wp-cli/pull/2458), adds `pre_colorized` arg to various functions, and adds `Ascii::set/isPreColorized()` and `Table::set/isAsciiPreColorize()` (the latter to be used via a corresponding `ascii_pre_colorized` arg to be added to `WP_CLI/Formatter`, see https://github.com/gitlost/wp-cli/pull/15.)

Also centralizes decolorization into `Colors::decolorize()`, adding a `keep` arg to optionally keep either tokens or encodings.

Also makes sure `Colors::colorize()` only reads from cache after checking `shouldColorize()`.

Also marks as unused the `colored` arg to `Colors::cacheString()`, and stops using the `decolorized` cache element in `length()` and `width()` as it never gets looked up if passed a colorized string (as they're indexed on the original string).

Also replicates the padding logic of `safe_str_pad()` in `Colors::pad()` and moves decolorization to `Colors::width()`, as it seems better that low-level funcs don't reference `Colors`.

Also makes `length` arg of `safe_substr()` cross PHP compat whether `null` or `false`.

Also adds an optional `encoding` arg to various functions to save some processing, and makes `mb_detect_encoding()` use strict.