### PR TITLE
Suppress tput stderr. Use COLUMNS env var 1st if available.

### DIFF
--- a/lib/cli/Shell.php
+++ b/lib/cli/Shell.php
@@ -49,8 +49,10 @@ class Shell {
 						}
 					}
 				} else {
-					if ( getenv( 'TERM' ) ) {
-						$columns = (int) exec( '/usr/bin/env tput cols' );
+					if ( ! ( $columns = (int) getenv( 'COLUMNS' ) ) ) {
+						if ( getenv( 'TERM' ) ) {
+							$columns = (int) exec( '/usr/bin/env tput cols 2>/dev/null' );
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Fixes #112 

In `Shell::columns()` uses the `COLUMNS` environment variable first if available, and suppresses any errors on invoking `tput` by redirecting to `/dev/null`.

Didn't bother with trying `stty` as `COLUMNS` should basically always work I think.