### PR TITLE
Optimize double-width safe_substr when all double-width.

### DIFF
--- a/lib/cli/cli.php
+++ b/lib/cli/cli.php
@@ -203,15 +203,23 @@ function safe_substr( $str, $start, $length = false, $is_width = false, $encodin
 			$eaw_regex = get_unicode_regexs( 'eaw' );
 			// If there's any East Asian double-width chars...
 			if ( preg_match( $eaw_regex, $substr ) ) {
-				// Explode string into an array of UTF-8 chars. Based on core `_mb_substr()` in "wp-includes/compat.php".
-				$chars = preg_split( '/([\x00-\x7f\xc2-\xf4][^\x00-\x7f\xc2-\xf4]*)/', $substr, $length + 1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY );
-				$cnt = min( count( $chars ), $length );
-				$width = $length;
+				// Note that if the length ends in the middle of a double-width char, the char is included, not excluded.
 
-				for ( $length = 0; $length < $cnt && $width > 0; $length++ ) {
-					$width -= preg_match( $eaw_regex, $chars[ $length ] ) ? 2 : 1;
+				// See if it's all EAW - the most likely case.
+				if ( preg_match_all( $eaw_regex, $substr ) === $length ) {
+					// Just halve the length so (rounded up).
+					$substr = mb_substr( $substr, 0, (int) ( ( $length + 1 ) / 2 ), $encoding );
+				} else {
+					// Explode string into an array of UTF-8 chars. Based on core `_mb_substr()` in "wp-includes/compat.php".
+					$chars = preg_split( '/([\x00-\x7f\xc2-\xf4][^\x00-\x7f\xc2-\xf4]*)/', $substr, $length + 1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY );
+					$cnt = min( count( $chars ), $length );
+					$width = $length;
+
+					for ( $length = 0; $length < $cnt && $width > 0; $length++ ) {
+						$width -= preg_match( $eaw_regex, $chars[ $length ] ) ? 2 : 1;
+					}
+					return join( '', array_slice( $chars, 0, $length ) );
 				}
-				return join( '', array_slice( $chars, 0, $length ) );
 			}
 		}
 	} else {
@@ -279,7 +287,7 @@ function strwidth( $string, $encoding = false ) {
 			return $width;
 		}
 	}
-	return safe_strlen( $string );
+	return safe_strlen( $string, $encoding );
 }
 
 /**

--- a/lib/cli/cli.php
+++ b/lib/cli/cli.php
@@ -202,7 +202,7 @@ function safe_substr( $str, $start, $length = false, $is_width = false, $encodin
 			// Set the East Asian Width regex.
 			$eaw_regex = get_unicode_regexs( 'eaw' );
 			// If there's any East Asian double-width chars...
-			if ( preg_match( $eaw_regex, $substr ) ) {
+			if ( preg_match( $eaw_regex, $substr, $dummy /*needed for PHP 5.3*/ ) ) {
 				// Note that if the length ends in the middle of a double-width char, the char is included, not excluded.
 
 				// See if it's all EAW - the most likely case.

--- a/lib/cli/cli.php
+++ b/lib/cli/cli.php
@@ -202,11 +202,11 @@ function safe_substr( $str, $start, $length = false, $is_width = false, $encodin
 			// Set the East Asian Width regex.
 			$eaw_regex = get_unicode_regexs( 'eaw' );
 			// If there's any East Asian double-width chars...
-			if ( preg_match( $eaw_regex, $substr, $dummy /*needed for PHP 5.3*/ ) ) {
+			if ( preg_match( $eaw_regex, $substr ) ) {
 				// Note that if the length ends in the middle of a double-width char, the char is included, not excluded.
 
 				// See if it's all EAW - the most likely case.
-				if ( preg_match_all( $eaw_regex, $substr ) === $length ) {
+				if ( preg_match_all( $eaw_regex, $substr, $dummy /*needed for PHP 5.3*/ ) === $length ) {
 					// Just halve the length so (rounded up).
 					$substr = mb_substr( $substr, 0, (int) ( ( $length + 1 ) / 2 ), $encoding );
 				} else {

--- a/lib/cli/table/Ascii.php
+++ b/lib/cli/table/Ascii.php
@@ -136,7 +136,7 @@ class Ascii extends Renderer {
 				$col_width = $this->_widths[ $col ];
 				$encoding = function_exists( 'mb_detect_encoding' ) ? mb_detect_encoding( $value, null, true /*strict*/ ) : false;
 				$original_val_width = Colors::width( $value, self::isPreColorized( $col ), $encoding );
-				if ( $original_val_width > $col_width ) {
+				if ( $col_width && $original_val_width > $col_width ) {
 					$row[ $col ] = \cli\safe_substr( $value, 0, $col_width, true /*is_width*/, $encoding );
 					$value = \cli\safe_substr( $value, \cli\safe_strlen( $row[ $col ], $encoding ), null /*length*/, false /*is_width*/, $encoding );
 					$i = 0;

--- a/tests/test-cli.php
+++ b/tests/test-cli.php
@@ -95,8 +95,8 @@ class testsCli extends PHPUnit_Framework_TestCase {
 		$this->assertSame( 'he',  \cli\safe_substr( Colors::pad( 'hello', 6 ), 0, 2, true /*is_width*/ ) );
 		$this->assertSame( 'ór', \cli\safe_substr( Colors::pad( 'óra', 6 ), 0, 2, true /*is_width*/ ) );
 		$this->assertSame( '日', \cli\safe_substr( Colors::pad( '日本語', 8 ), 0, 2, true /*is_width*/ ) );
+		$this->assertSame( '日', \cli\safe_substr( Colors::pad( '日本語', 8 ), 0, 3, true /*is_width*/ ) );
 		$this->assertSame( '日本', \cli\safe_substr( Colors::pad( '日本語', 8 ), 0, 4, true /*is_width*/ ) );
-		$this->assertSame( '日本', \cli\safe_substr( Colors::pad( '日本語', 8 ), 0, 3, true /*is_width*/ ) );
 		$this->assertSame( '日本語', \cli\safe_substr( Colors::pad( '日本語', 8 ), 0, 6, true /*is_width*/ ) );
 		$this->assertSame( '日本語 ', \cli\safe_substr( Colors::pad( '日本語', 8 ), 0, 7, true /*is_width*/ ) );
 
@@ -107,12 +107,12 @@ class testsCli extends PHPUnit_Framework_TestCase {
 
 		$this->assertSame( '', \cli\safe_substr( '1日4本語90', 0, 0, true /*is_width*/ ) );
 		$this->assertSame( '1', \cli\safe_substr( '1日4本語90', 0, 1, true /*is_width*/ ) );
-		$this->assertSame( '1日', \cli\safe_substr( '1日4本語90', 0, 2, true /*is_width*/ ) );
+		$this->assertSame( '1', \cli\safe_substr( '1日4本語90', 0, 2, true /*is_width*/ ) );
 		$this->assertSame( '1日', \cli\safe_substr( '1日4本語90', 0, 3, true /*is_width*/ ) );
 		$this->assertSame( '1日4', \cli\safe_substr( '1日4本語90', 0, 4, true /*is_width*/ ) );
-		$this->assertSame( '1日4本', \cli\safe_substr( '1日4本語90', 0, 5, true /*is_width*/ ) );
+		$this->assertSame( '1日4', \cli\safe_substr( '1日4本語90', 0, 5, true /*is_width*/ ) );
 		$this->assertSame( '1日4本', \cli\safe_substr( '1日4本語90', 0, 6, true /*is_width*/ ) );
-		$this->assertSame( '1日4本語', \cli\safe_substr( '1日4本語90', 0, 7, true /*is_width*/ ) );
+		$this->assertSame( '1日4本', \cli\safe_substr( '1日4本語90', 0, 7, true /*is_width*/ ) );
 		$this->assertSame( '1日4本語', \cli\safe_substr( '1日4本語90', 0, 8, true /*is_width*/ ) );
 		$this->assertSame( '1日4本語9', \cli\safe_substr( '1日4本語90', 0, 9, true /*is_width*/ ) );
 		$this->assertSame( '1日4本語90', \cli\safe_substr( '1日4本語90', 0, 10, true /*is_width*/ ) );
@@ -124,7 +124,7 @@ class testsCli extends PHPUnit_Framework_TestCase {
 
 		$this->assertSame( '本', \cli\safe_substr( '1日4本語90', 3, 1, true /*is_width*/ ) );
 		$this->assertSame( '本', \cli\safe_substr( '1日4本語90', 3, 2, true /*is_width*/ ) );
-		$this->assertSame( '本語', \cli\safe_substr( '1日4本語90', 3, 3, true /*is_width*/ ) );
+		$this->assertSame( '本', \cli\safe_substr( '1日4本語90', 3, 3, true /*is_width*/ ) );
 		$this->assertSame( '本語', \cli\safe_substr( '1日4本語90', 3, 4, true /*is_width*/ ) );
 		$this->assertSame( '本語9', \cli\safe_substr( '1日4本語90', 3, 5, true /*is_width*/ ) );
 

--- a/tests/test-table.php
+++ b/tests/test-table.php
@@ -55,6 +55,50 @@ class Test_Table extends PHPUnit_Framework_TestCase {
 		}
 	}
 
+	public function test_column_odd_single_width_with_double_width() {
+
+		$dummy = new cli\Table;
+		$renderer = new cli\Table\Ascii;
+
+		$strip_borders = function ( $a ) {
+			return array_map( function ( $v ) {
+				return substr( $v, 2, -2 );
+			}, $a );
+		};
+
+		$renderer->setWidths( array( 10 ) );
+
+		// 1 single-width, 6 double-width, 1 single-width, 2 double-width, 1 half-width, 2 double-width.
+		$out = $renderer->row( array( '1あいうえおか2きくｶけこ' ) );
+		$result = $strip_borders( explode( "\n", $out ) );
+
+		$this->assertSame( 3, count( $result ) );
+		$this->assertSame( '1あいうえ ', $result[0] ); // 1 single width, 4 double-width, space = 10.
+		$this->assertSame( 'おか2きくｶ', $result[1] ); // 2 double-width, 1 single-width, 2 double-width, 1 half-width = 10.
+		$this->assertSame( 'けこ      ', $result[2] ); // 2 double-width, 8 spaces = 10.
+
+		// Minimum width 1.
+
+		$renderer->setWidths( array( 1 ) );
+
+		$out = $renderer->row( array( '1あいうえおか2きくｶけこ' ) );
+		$result = $strip_borders( explode( "\n", $out ) );
+
+		$this->assertSame( 13, count( $result ) );
+		// Uneven rows.
+		$this->assertSame( '1', $result[0] );
+		$this->assertSame( 'あ', $result[1] );
+
+		// Zero width does no wrapping.
+
+		$renderer->setWidths( array( 0 ) );
+
+		$out = $renderer->row( array( '1あいうえおか2きくｶけこ' ) );
+		$result = $strip_borders( explode( "\n", $out ) );
+
+		$this->assertSame( 1, count( $result ) );
+	}
+
 	public function test_ascii_pre_colorized_widths() {
 
 		Colors::enable( true );


### PR DESCRIPTION
Related https://github.com/wp-cli/php-cli-tools/pull/111

Looking at the @miya0001's test table at https://github.com/wp-cli/php-cli-tools/pull/111#pullrequestreview-52207165 it struck me that most of the time a column with double-width chars will have a number of entries with double-width content only, which suggests this simple optimization which checks for this using a `preg_match_all()` and just halves the length if so.

Crude benchmarking suggests a performance win if the percentage of such entries is above 10% or so, and only a small (2%) penalty if it's less than that, and a major win (100s of %) if it's anything above 50%, which I'm guessing is most likely to be the case - @miya0001 could you comment on whether this is likely in your experience for real data?
