### PR TITLE
Use grapheme_substr & pcre_match in safe_substr for #117. Ascii::columns fix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ php:
     - 5.5
     - 5.6
 
+before_script:
+  - php -m
+  - php --info | grep -i 'intl\|pcre'
+
 script: phpunit
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,14 @@ php:
     - 5.4
     - 5.5
     - 5.6
+    - 7.0
+    - 7.1
 
 before_script:
   - php -m
-  - php --info | grep -i 'intl\|pcre'
+  - php --info | grep -i 'intl\|icu\|pcre'
 
-script: phpunit
+script: phpunit --debug
 
 notifications:
     email:

--- a/lib/cli/Shell.php
+++ b/lib/cli/Shell.php
@@ -50,12 +50,12 @@ class Shell {
 					}
 				} else {
 					if ( ! ( $columns = (int) getenv( 'COLUMNS' ) ) ) {
-						$size = exec( '/usr/bin/env stty size 2>/dev/null' );
-						if ( '' !== $size && preg_match( '/[0-9]+ ([0-9]+)/', $size, $matches ) ) {
-							$columns = (int) $matches[1];
-						}
-						if ( ! $columns ) {
-							if ( getenv( 'TERM' ) ) {
+						if ( getenv( 'TERM' ) ) {
+							$size = exec( '/usr/bin/env stty size 2>/dev/null' );
+							if ( '' !== $size && preg_match( '/[0-9]+ ([0-9]+)/', $size, $matches ) ) {
+								$columns = (int) $matches[1];
+							}
+							if ( ! $columns ) {
 								$columns = (int) exec( '/usr/bin/env tput cols 2>/dev/null' );
 							}
 						}

--- a/lib/cli/Shell.php
+++ b/lib/cli/Shell.php
@@ -50,12 +50,12 @@ class Shell {
 					}
 				} else {
 					if ( ! ( $columns = (int) getenv( 'COLUMNS' ) ) ) {
-						if ( getenv( 'TERM' ) ) {
-							$size = exec( '/usr/bin/env stty size 2>/dev/null' );
-							if ( '' !== $size && preg_match( '/[0-9]+ ([0-9]+)/', $size, $matches ) ) {
-								$columns = (int) $matches[1];
-							}
-							if ( ! $columns ) {
+						$size = exec( '/usr/bin/env stty size 2>/dev/null' );
+						if ( '' !== $size && preg_match( '/[0-9]+ ([0-9]+)/', $size, $matches ) ) {
+							$columns = (int) $matches[1];
+						}
+						if ( ! $columns ) {
+							if ( getenv( 'TERM' ) ) {
 								$columns = (int) exec( '/usr/bin/env tput cols 2>/dev/null' );
 							}
 						}

--- a/lib/cli/Shell.php
+++ b/lib/cli/Shell.php
@@ -50,8 +50,14 @@ class Shell {
 					}
 				} else {
 					if ( ! ( $columns = (int) getenv( 'COLUMNS' ) ) ) {
-						if ( getenv( 'TERM' ) ) {
-							$columns = (int) exec( '/usr/bin/env tput cols 2>/dev/null' );
+						$size = exec( '/usr/bin/env stty size 2>/dev/null' );
+						if ( '' !== $size && preg_match( '/[0-9]+ ([0-9]+)/', $size, $matches ) ) {
+							$columns = (int) $matches[1];
+						}
+						if ( ! $columns ) {
+							if ( getenv( 'TERM' ) ) {
+								$columns = (int) exec( '/usr/bin/env tput cols 2>/dev/null' );
+							}
 						}
 					}
 				}

--- a/lib/cli/table/Ascii.php
+++ b/lib/cli/table/Ascii.php
@@ -40,8 +40,8 @@ class Ascii extends Renderer {
 			$this->_constraintWidth = (int) Shell::columns();
 		}
 		$col_count = count( $widths );
-		$col_borders_count = $col_count * strlen( $this->_characters['border'] );
-		$table_borders_count = strlen( $this->_characters['border'] ) * 1;
+		$col_borders_count = $col_count ? ( ( $col_count - 1 ) * strlen( $this->_characters['border'] ) ) : 0;
+		$table_borders_count = strlen( $this->_characters['border'] ) * 2;
 		$col_padding_count = $col_count * strlen( $this->_characters['padding'] ) * 2;
 		$max_width = $this->_constraintWidth - $col_borders_count - $table_borders_count - $col_padding_count;
 
@@ -63,11 +63,11 @@ class Ascii extends Renderer {
 				foreach( $widths as &$width ) {
 					if ( in_array( $width, $resize_widths ) ) {
 						$width = $avg + $avg_extra_width;
-						$extra_width = $extra_width - $avg_extra_width;
 						array_shift( $resize_widths );
 						// Last item gets the cake
 						if ( empty( $resize_widths ) ) {
-							$width = $width + $extra_width;
+							$width = 0; // Zero it so not in sum.
+							$width = $max_width - array_sum( $widths );
 						}
 					}
 				}
@@ -131,7 +131,7 @@ class Ascii extends Renderer {
 
 			foreach( $row as $col => $value ) {
 
-				$value = str_replace( PHP_EOL, ' ', $value );
+				$value = str_replace( array( "\r\n", "\n" ), ' ', $value );
 
 				$col_width = $this->_widths[ $col ];
 				$encoding = function_exists( 'mb_detect_encoding' ) ? mb_detect_encoding( $value, null, true /*strict*/ ) : false;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,6 +2,13 @@
 
 require dirname( dirname( __FILE__ ) ) . '/lib/cli/cli.php';
 
+/**
+ * Compatibility with PHPUnit 6+
+ */
+if ( class_exists( 'PHPUnit\Runner\Version' ) ) {
+	require_once dirname( __FILE__ ) . '/phpunit6-compat.php';
+}
+
 function cli_autoload( $className ) {
 	$className = ltrim($className, '\\');
 	$fileName  = '';

--- a/tests/phpunit6-compat.php
+++ b/tests/phpunit6-compat.php
@@ -1,0 +1,19 @@
+<?php
+// From core "tests/phpunit/includes/phpunit6-compat.php" without `getTickets()` (see https://core.trac.wordpress.org/ticket/39822).
+
+if ( class_exists( 'PHPUnit\Runner\Version' ) && version_compare( PHPUnit\Runner\Version::id(), '6.0', '>=' ) ) {
+
+	class_alias( 'PHPUnit\Framework\TestCase',                   'PHPUnit_Framework_TestCase' );
+	class_alias( 'PHPUnit\Framework\Exception',                  'PHPUnit_Framework_Exception' );
+	class_alias( 'PHPUnit\Framework\ExpectationFailedException', 'PHPUnit_Framework_ExpectationFailedException' );
+	class_alias( 'PHPUnit\Framework\Error\Notice',               'PHPUnit_Framework_Error_Notice' );
+	class_alias( 'PHPUnit\Framework\Error\Warning',              'PHPUnit_Framework_Error_Warning' );
+	class_alias( 'PHPUnit\Framework\Test',                       'PHPUnit_Framework_Test' );
+	class_alias( 'PHPUnit\Framework\Warning',                    'PHPUnit_Framework_Warning' );
+	class_alias( 'PHPUnit\Framework\AssertionFailedError',       'PHPUnit_Framework_AssertionFailedError' );
+	class_alias( 'PHPUnit\Framework\TestSuite',                  'PHPUnit_Framework_TestSuite' );
+	class_alias( 'PHPUnit\Framework\TestListener',               'PHPUnit_Framework_TestListener' );
+	class_alias( 'PHPUnit\Util\GlobalState',                     'PHPUnit_Util_GlobalState' );
+	class_alias( 'PHPUnit\Util\Getopt',                          'PHPUnit_Util_Getopt' );
+
+}

--- a/tests/test-cli.php
+++ b/tests/test-cli.php
@@ -104,7 +104,7 @@ class testsCli extends PHPUnit_Framework_TestCase {
 		// Latin, kana, Latin, Latin combining, Thai combining, Hangul.
 		$str = 'lムnöม้p를';
 
-		if ( function_exists( 'grapheme_substr' ) ) {
+		if ( \cli\can_use_icu() ) {
 			putenv( 'PHP_CLI_TOOLS_TEST_SAFE_SUBSTR=1' ); // Tests grapheme_substr().
 			$this->assertSame( '', \cli\safe_substr( $str, 0, 0 ) );
 			$this->assertSame( 'l', \cli\safe_substr( $str, 0, 1 ) );
@@ -381,7 +381,7 @@ class testsCli extends PHPUnit_Framework_TestCase {
 		// 4 characters, one a double-width Han = 5 spacing chars, with 2 combining chars. Adapted from http://unicode.org/faq/char_combmark.html#7 (combining acute accent added after "a").
 		$str = "a\xCC\x81\xE0\xA4\xA8\xE0\xA4\xBF\xE4\xBA\x9C\xF0\x90\x82\x83";
 
-		if ( function_exists( 'grapheme_strlen' ) ) {
+		if ( \cli\can_use_icu() ) {
 			$this->assertSame( 5, \cli\strwidth( $str ) ); // Tests grapheme_strlen().
 			putenv( 'PHP_CLI_TOOLS_TEST_STRWIDTH=2' ); // Test preg_match_all( '/\X/u' ).
 			$this->assertSame( 5, \cli\strwidth( $str ) );
@@ -396,7 +396,7 @@ class testsCli extends PHPUnit_Framework_TestCase {
 		}
 
 		putenv( 'PHP_CLI_TOOLS_TEST_STRWIDTH=8' ); // Test safe_strlen().
-		if ( function_exists( 'grapheme_strlen' ) || \cli\can_use_pcre_x() ) {
+		if ( \cli\can_use_icu() || \cli\can_use_pcre_x() ) {
 			$this->assertSame( 4, \cli\strwidth( $str ) ); // safe_strlen() (correctly) does not account for double-width Han so out by 1.
 		} elseif ( function_exists( 'mb_strlen' ) && function_exists( 'mb_detect_order' ) ) {
 			$this->assertSame( 4, \cli\strwidth( $str ) ); // safe_strlen() (correctly) does not account for double-width Han so out by 1.
@@ -411,7 +411,7 @@ class testsCli extends PHPUnit_Framework_TestCase {
 
 		putenv( 'PHP_CLI_TOOLS_TEST_STRWIDTH' );
 
-		if ( function_exists( 'grapheme_strlen' ) ) {
+		if ( \cli\can_use_icu() ) {
 			$this->assertSame( 11, \cli\strwidth( $str ) ); // Tests grapheme_strlen().
 			putenv( 'PHP_CLI_TOOLS_TEST_STRWIDTH=2' ); // Test preg_match_all( '/\X/u' ).
 			$this->assertSame( 11, \cli\strwidth( $str ) );
@@ -473,7 +473,7 @@ class testsCli extends PHPUnit_Framework_TestCase {
 		// ASCII l, 3-byte kana, ASCII n, ASCII o + 2-byte combining umlaut, 6-byte Thai combining, ASCII, 3-byte Hangul. grapheme length 7, bytes 18.
 		$str = 'lムnöม้p를';
 
-		if ( function_exists( 'grapheme_strlen' ) ) {
+		if ( \cli\can_use_icu() ) {
 			putenv( 'PHP_CLI_TOOLS_TEST_SAFE_STRLEN' ); // Test grapheme_strlen().
 			$this->assertSame( 7, \cli\safe_strlen( $str ) );
 			if ( \cli\can_use_pcre_x() ) {

--- a/tests/test-colors.php
+++ b/tests/test-colors.php
@@ -8,6 +8,9 @@ class testsColors extends PHPUnit_Framework_TestCase {
      * @dataProvider dataColors
 	 */ 
 	function testColors( $str, $color ) {
+		// Colors enabled.
+		Colors::enable( true );
+
 		$colored = Colors::color( $color );
 		$this->assertSame( Colors::colorize( $str ), Colors::color( $color ) );
 		if ( in_array( 'reset', $color ) ) {

--- a/tests/test-shell.php
+++ b/tests/test-shell.php
@@ -22,6 +22,7 @@ class TestShell extends PHPUnit_Framework_TestCase {
 		// No TERM should result in default 80.
 
 		putenv( 'TERM' );
+		putenv( 'COLUMNS=80' );
 
 		putenv( 'WP_CLI_TEST_IS_WINDOWS=0' );
 		$columns = cli\Shell::columns();

--- a/tests/test-table.php
+++ b/tests/test-table.php
@@ -7,7 +7,7 @@ use cli\Colors, cli\Table, cli\Table\Ascii;
  */
 class Test_Table extends PHPUnit_Framework_TestCase {
 
-	public function test_column_value_too_long() {
+	public function test_column_value_too_long_ascii() {
 
 		$constraint_width = 80;
 
@@ -20,21 +20,30 @@ class Test_Table extends PHPUnit_Framework_TestCase {
 		$table->addRow( array( 'author', '<a href="http://wordpress.org/" title="Visit author homepage">the WordPress team</a>' ) );
 
 		$out = $table->getDisplayLines();
-		// "+ 1" accommodates "\n"
 		$this->assertCount( 12, $out );
-		$this->assertEquals( $constraint_width, strlen( $out[0] ) + 1 );
-		$this->assertEquals( $constraint_width, strlen( $out[1] ) + 1 );
-		$this->assertEquals( $constraint_width, strlen( $out[2] ) + 1 );
-		$this->assertEquals( $constraint_width, strlen( $out[3] ) + 1 );
-		$this->assertEquals( $constraint_width, strlen( $out[4] ) + 1 );
-		$this->assertEquals( $constraint_width, strlen( $out[5] ) + 1 );
-		$this->assertEquals( $constraint_width, strlen( $out[6] ) + 1 );
-		$this->assertEquals( $constraint_width, strlen( $out[7] ) + 1 );
-		$this->assertEquals( $constraint_width, strlen( $out[8] ) + 1 );
-		$this->assertEquals( $constraint_width, strlen( $out[9] ) + 1 );
-		$this->assertEquals( $constraint_width, strlen( $out[10] ) + 1 );
-		$this->assertEquals( $constraint_width, strlen( $out[11] ) + 1 );
+		$this->assertEquals( $constraint_width, strlen( $out[0] ) );
+		$this->assertEquals( $constraint_width, strlen( $out[1] ) );
+		$this->assertEquals( $constraint_width, strlen( $out[2] ) );
+		$this->assertEquals( $constraint_width, strlen( $out[3] ) );
+		$this->assertEquals( $constraint_width, strlen( $out[4] ) );
+		$this->assertEquals( $constraint_width, strlen( $out[5] ) );
+		$this->assertEquals( $constraint_width, strlen( $out[6] ) );
+		$this->assertEquals( $constraint_width, strlen( $out[7] ) );
+		$this->assertEquals( $constraint_width, strlen( $out[8] ) );
+		$this->assertEquals( $constraint_width, strlen( $out[9] ) );
+		$this->assertEquals( $constraint_width, strlen( $out[10] ) );
+		$this->assertEquals( $constraint_width, strlen( $out[11] ) );
 
+		$constraint_width = 81;
+
+		$renderer = new cli\Table\Ascii;
+		$renderer->setConstraintWidth( $constraint_width );
+		$table->setRenderer( $renderer );
+
+		$out = $table->getDisplayLines();
+		for ( $i = 0; $i < count( $out ); $i++ ) {
+			$this->assertEquals( $constraint_width, strlen( $out[ $i ] ) );
+		}
 	}
 
 	public function test_column_value_too_long_with_multibytes() {
@@ -51,7 +60,18 @@ class Test_Table extends PHPUnit_Framework_TestCase {
 
 		$out = $table->getDisplayLines();
 		for ( $i = 0; $i < count( $out ); $i++ ) {
-			$this->assertEquals( $constraint_width, \cli\strwidth( $out[$i] ) + 1 );
+			$this->assertEquals( $constraint_width, \cli\strwidth( $out[$i] ) );
+		}
+
+		$constraint_width = 81;
+
+		$renderer = new cli\Table\Ascii;
+		$renderer->setConstraintWidth( $constraint_width );
+		$table->setRenderer( $renderer );
+
+		$out = $table->getDisplayLines();
+		for ( $i = 0; $i < count( $out ); $i++ ) {
+			$this->assertEquals( $constraint_width, \cli\strwidth( $out[$i] ) );
 		}
 	}
 
@@ -97,6 +117,61 @@ class Test_Table extends PHPUnit_Framework_TestCase {
 		$result = $strip_borders( explode( "\n", $out ) );
 
 		$this->assertSame( 1, count( $result ) );
+	}
+
+	public function test_column_fullwidth_and_combining() {
+
+		$constraint_width = 80;
+
+		$table = new cli\Table;
+		$renderer = new cli\Table\Ascii;
+		$renderer->setConstraintWidth( $constraint_width );
+		$table->setRenderer( $renderer );
+		$table->setHeaders( array( 'Field', 'Value' ) );
+		$table->addRow( array( 'ID', 2151 ) );
+		$table->addRow( array( 'post_author', 1 ) );
+		$table->addRow( array( 'post_title', 'only-english-lorem-ipsum-dolor-sit-amet-consectetur-adipisicing-elit-sed-do-eiusmod-tempor-incididunt-ut-labore' ) );
+		$table->addRow( array( 'post_content',
+			//'ให้รู้จัก ให้หาหนทางใหม่' .
+			'♫ มีอีกหลายต่อหลายคน เขาอดทนก็เพื่อรัก' . "\n" .
+			'รักผลักดันให้รู้จัก ให้หาหนทางใหม่' . "\r\n" .
+			'ฉันจะล้มตั้งหลายที ดีที่รักมาฉุดไว้' . "\r\n" .
+			'รักสร้างสรรค์สิ่งมากมาย และหลอมละลายทุกหัวใจ' . "\r\n" .
+			'จะมาร้ายดียังไง แต่ใจก็ยังต้องการ' . "\r\n" .
+			'ในทุกๆ วัน โลกหมุนด้วยความรัก ♫' . "\n" .
+			'ขอแสดงความยินดี งานแต่งพี่ Earn & Menn' ."\r\n" .
+			'เที่ยวปายหน้าร้อน ก็เที่ยวได้เหมือนกันน่ะ' . "\r\n" .
+			' ジョバンニはまっ赤になってうなずきました。けれどもいつかジョバンニの眼のなかには涙がいっぱいになりました。そうだ僕は知っていたのだ、もちろんカムパネルラも知っている。' ."\r\n" .
+			'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore' . "\n" .
+			''
+		) );
+
+		$out = $table->getDisplayLines();
+		for ( $i = 0; $i < count( $out ); $i++ ) {
+			$this->assertEquals( $constraint_width, \cli\strwidth( $out[$i] ) );
+		}
+
+		$constraint_width = 81;
+
+		$renderer = new cli\Table\Ascii;
+		$renderer->setConstraintWidth( $constraint_width );
+		$table->setRenderer( $renderer );
+
+		$out = $table->getDisplayLines();
+		for ( $i = 0; $i < count( $out ); $i++ ) {
+			$this->assertEquals( $constraint_width, \cli\strwidth( $out[$i] ) );
+		}
+
+		$constraint_width = 200;
+
+		$renderer = new cli\Table\Ascii;
+		$renderer->setConstraintWidth( $constraint_width );
+		$table->setRenderer( $renderer );
+
+		$out = $table->getDisplayLines();
+		for ( $i = 0; $i < count( $out ); $i++ ) {
+			$this->assertEquals( $constraint_width, \cli\strwidth( $out[$i] ) );
+		}
 	}
 
 	public function test_ascii_pre_colorized_widths() {


### PR DESCRIPTION
Issue https://github.com/wp-cli/php-cli-tools/issues/117

Uses `grapheme_substr()` and `preg_match()` in `safe_substr()` (and `grapheme_strlen()` and `preg_match_all()` in `safe_strlen()`) to deal with combining characters correctly, in a manner similar to that in `strwidth()`.

Refactors the East Asian Width stuff into a function `_safe_substr_eaw()` and adds `can_use_pcre_x()` helper to check for PCRE `\X` availability.

Removes use of `iconv()` as it varies widely over PHP versions and isn't easily tested and wasn't that useful anyway.

Incorporates the test data from @ShinichiNishikawa.

Fixes a gatepost error in `Ascii::setWidths()`.

Also tries `stty` as well in `Shell::columns()` as relying on the env var `COLUMNS` as introduced by me in https://github.com/wp-cli/php-cli-tools/pull/113 turns out not to be that great as it's not normally exported. Sigh.

Edit: had to add an ICU check function to guard against the old 4.8.1.1 version on Travis (all PHP versions) flaking out - chose 54.1 as min which is Unicode 7.0 and fairly modern.

Also added "phpunit6-compat.php" from core (as introduced by @miya0001 in https://core.trac.wordpress.org/ticket/39822), modded to remove the `getTickets()`, and PHP 7.0 & 7.1 to the Travis build, and some php info and the `--debug` switch on phpunit.