### PR TITLE
adding optional msg parameter to \cli\Progress\Bar::tick()

### DIFF
--- a/examples/common.php
+++ b/examples/common.php
@@ -26,7 +26,7 @@ function test_notify(cli\Notify $notify, $cycle = 1000000, $sleep = null) {
 
 function test_notify_msg(cli\Notify $notify, $cycle = 1000000, $sleep = null) {
 	$notify->display();
-	for ($i = 0; $i <= $cycle; $i++) {
+	for ($i = 0; $i < $cycle; $i++) {
 		// Sleep before tick to simulate time-intensive work and give time
 		// for the initial message to display before it is changed
 		if ($sleep) usleep($sleep);

--- a/examples/common.php
+++ b/examples/common.php
@@ -23,3 +23,15 @@ function test_notify(cli\Notify $notify, $cycle = 1000000, $sleep = null) {
 	}
 	$notify->finish();
 }
+
+function test_notify_msg(cli\Notify $notify, $cycle = 1000000, $sleep = null) {
+	$notify->display();
+	for ($i = 0; $i <= $cycle; $i++) {
+		// Sleep before tick to simulate time-intensive work and give time
+		// for the initial message to display before it is changed
+		if ($sleep) usleep($sleep);
+		$msg = sprintf('  Finished step %d', $i + 1);
+		$notify->tick(1, $msg);
+	}
+	$notify->finish();
+}

--- a/examples/progress.php
+++ b/examples/progress.php
@@ -4,3 +4,4 @@ require_once 'common.php';
 
 test_notify(new \cli\progress\Bar('  \cli\progress\Bar displays a progress bar', 1000000));
 test_notify(new \cli\progress\Bar('  It sizes itself dynamically', 1000000));
+test_notify_msg(new \cli\progress\Bar('  It can even change its message', 5), 4, 1000000);

--- a/examples/progress.php
+++ b/examples/progress.php
@@ -4,4 +4,4 @@ require_once 'common.php';
 
 test_notify(new \cli\progress\Bar('  \cli\progress\Bar displays a progress bar', 1000000));
 test_notify(new \cli\progress\Bar('  It sizes itself dynamically', 1000000));
-test_notify_msg(new \cli\progress\Bar('  It can even change its message', 5), 4, 1000000);
+test_notify_msg(new \cli\progress\Bar('  It can even change its message', 5), 5, 1000000);

--- a/lib/cli/progress/Bar.php
+++ b/lib/cli/progress/Bar.php
@@ -13,6 +13,7 @@
 namespace cli\progress;
 
 use cli;
+use cli\Notify;
 use cli\Progress;
 use cli\Shell;
 use cli\Streams;
@@ -65,5 +66,20 @@ class Bar extends Progress {
 		$bar = substr(str_pad($bar, $size, ' '), 0, $size);
 
 		Streams::out($this->_format, compact('msg', 'bar', 'timing'));
+	}
+
+	/**
+	 * This method augments the base definition from cli\Notify to optionally
+	 * allow passing a new message.
+	 *
+	 * @param int    $increment The amount to increment by.
+	 * @param string $msg       The text to display next to the Notifier. (optional)
+	 * @see cli\Notify::tick()
+	 */
+	public function tick($increment = 1, $msg = null) {
+		if ($msg) {
+			$this->_message = $msg;
+		}
+		Notify::tick($increment);
 	}
 }


### PR DESCRIPTION
As discussed in #125 

The tick method of `\cli\Notify::tick()` is augmented in its grandchild class, `\cli\Progress\Bar` to have an optional second parameter which updates its `_message` property. As items are processed, the message may be optionally changed to reflect the nature of the work being performed.

The current behavior of the progress bar suppresses any output until the first tick occurs. In use cases where the developer wishes to display the initial message and then alter it during the first tick, they should manually call the public `display()` method of the progress bar before work is performed and the tick occurs.

The use case of displaying a message describing work about to be performed would be better served by supplementing this updated `tick()` method with a setter for the `_message` property whereby the message is manually changed before work is performed, then the tick is used to increment progress separately.