### PR TITLE
fixing off-by-1 error in progress bar examples

### DIFF
--- a/examples/common.php
+++ b/examples/common.php
@@ -17,7 +17,7 @@ foreach(array(__DIR__ . '/../vendor', __DIR__ . '/../../../../vendor') as $vendo
 }
 
 function test_notify(cli\Notify $notify, $cycle = 1000000, $sleep = null) {
-	for ($i = 0; $i <= $cycle; $i++) {
+	for ($i = 0; $i < $cycle; $i++) {
 		$notify->tick();
 		if ($sleep) usleep($sleep);
 	}


### PR DESCRIPTION
Fixes #127 

Resolves off-by-1 error in `test_notify` function.

While changing the comparison operator fixes this issue, the need for a tick count parameter could be avoided altogether as described in this [issue comment](https://github.com/wp-cli/php-cli-tools/issues/127#issuecomment-370519406). Given the normal use case is to tick a number of times equal to the progress bar tick `total`, the passed progress bar object could be introspected if appropriately exposed.
