### PR TITLE
Introduce concept of explicit commands

### DIFF
--- a/lib/cli/arguments/Argument.php
+++ b/lib/cli/arguments/Argument.php
@@ -39,7 +39,7 @@ class Argument extends Memoize {
 			$this->_argument = substr($this->_raw, 2);
 		} else if ($this->isShort) {
 			$this->_argument = substr($this->_raw, 1);
-		} else {
+		} else if ($this->isCommand) {
 			$this->_argument = $this->_raw;
 		}
 	}
@@ -87,6 +87,15 @@ class Argument extends Memoize {
 	 */
 	public function isShort() {
 		return !$this->isLong && (0 == strncmp($this->_raw, '-', 1));
+	}
+
+	/**
+	 * Returns true if the string matches the pattern for command arguments.
+	 *
+	 * @return bool
+	 */
+	public function isCommand() {
+		return !(0 == strncmp($this->_raw, '-', 1));
 	}
 
 	/**

--- a/test.php
+++ b/test.php
@@ -5,6 +5,14 @@ require_once __DIR__ . '/vendor/autoload.php';
 
 
 $args = new cli\Arguments(array(
+    'commands' => array(
+        'show' => array(
+            'description' => 'Show a JSON dump of the arguments'
+		),
+		'hide' => array(
+			'description' => 'Just to have another command'
+		)
+    ),
 	'flags' => array(
 		'verbose' => array(
 			'description' => 'Turn on verbose mode',
@@ -23,11 +31,17 @@ $args = new cli\Arguments(array(
 	),
 	'strict' => true
 ));
+$args->addFlag(array('help', 'h'), 'Show this help screen');
 
 try {
-    $args->parse();
-} catch (cli\InvalidArguments $e) {
-    echo $e->getMessage() . "\n\n";
+	$args->parse();
+	if ($args['flags']['help']) {
+		echo $args->getHelpScreen() . "\n\n";
+	}
+	if ($args['commands']['show']) {
+		echo $args->asJSON() . "\n";
+	}
+} catch (cli\arguments\InvalidArguments $e) {
+	echo 'Unrecognized parameters: ' . implode(',', $e->getArguments()) . "\n";
+	echo $args->getHelpScreen() . "\n\n";
 }
-
-print_r($args->getArguments());


### PR DESCRIPTION
Commands are top-level-only direct actions you can take using the script
Example: 
`php cli.php compress -a [file] --use-7zip
`

Previously, the following were all identical:
```
php cli.php -h
php cli.php --help
php cli.php help
```

This is a **breaking** change. Existing code must be altered to assert the
specific argument type they wish to access (i.e. flags, options, commands)

See updated test.php at root level for an example of this and basic
unrecognized command handling.

Help Screen output modified to include command list and descriptions.