### PR TITLE
Fix type hinting for prompt function

### DIFF
--- a/lib/cli/Streams.php
+++ b/lib/cli/Streams.php
@@ -156,7 +156,7 @@ class Streams {
 	 * @return string  The users input.
 	 * @see cli\input()
 	 */
-	public static function prompt( $question, $default = null, $marker = ': ', $hide = false ) {
+	public static function prompt( $question, $default = false, $marker = ': ', $hide = false ) {
 		if( $default && strpos( $question, '[' ) === false ) {
 			$question .= ' [' . $default . ']';
 		}

--- a/lib/cli/cli.php
+++ b/lib/cli/cli.php
@@ -94,7 +94,7 @@ function input( $format = null ) {
  * continue displaying until input is received.
  *
  * @param string  $question The question to ask the user.
- * @param bool|string  $default  A default value if the user provides no input.
+ * @param string|false  $default  A default value if the user provides no input. Default false.
  * @param string  $marker   A string to append to the question and default value on display.
  * @param boolean $hide     If the user input should be hidden
  * @return string  The users input.

--- a/lib/cli/cli.php
+++ b/lib/cli/cli.php
@@ -94,7 +94,7 @@ function input( $format = null ) {
  * continue displaying until input is received.
  *
  * @param string  $question The question to ask the user.
- * @param string  $default  A default value if the user provides no input.
+ * @param bool|string  $default  A default value if the user provides no input.
  * @param string  $marker   A string to append to the question and default value on display.
  * @param boolean $hide     If the user input should be hidden
  * @return string  The users input.


### PR DESCRIPTION
I was confused by `phpstan analyse` output: "Parameter #2 $default of function cli\prompt expects string, false given." Soon I found out that problem is in type hinting for this function in `lib/cli/cli.php`. Hope my fix is helpful.