### PR TITLE
Update Streams.php

### DIFF
--- a/lib/cli/Streams.php
+++ b/lib/cli/Streams.php
@@ -15,9 +15,9 @@ class Streams {
 
 	static public function isTty() {
 		if ( function_exists('stream_isatty') ) {
-			return !stream_isatty(static::$out);
+			return stream_isatty(static::$out);
 		} else {
-			return (function_exists('posix_isatty') && !posix_isatty(static::$out));
+			return (function_exists('posix_isatty') && posix_isatty(static::$out));
 		}
 	}
 


### PR DESCRIPTION
The function isTty() in Streams.php returns wrong information.
If the output is to an TTY then it returns false and if the output is a pipe or file it returns true, it should be the other way around.