### PR TITLE
[PHP 8.2] Fix `${var}` string interpolation deprecation

### DIFF
--- a/examples/menu.php
+++ b/examples/menu.php
@@ -19,6 +19,6 @@ while (true) {
 		break;
 	}
 
-	include "${choice}.php";
+	include "{$choice}.php";
 	\cli\line();
 }

--- a/lib/cli/arguments/HelpScreen.php
+++ b/lib/cli/arguments/HelpScreen.php
@@ -91,7 +91,7 @@ class HelpScreen {
 
 			$pad = str_repeat(' ', $max + 3);
 			while ($desc = array_shift($description)) {
-				$formatted .= "\n${pad}${desc}";
+				$formatted .= "\n{$pad}{$desc}";
 			}
 
 			array_push($help, $formatted);


### PR DESCRIPTION
PHP 8.2 deprecates `"${var}"` string interpolation pattern.
This fixes all three of such occurrences in `wp-cli/php-cli-tools` package.

 - [PHP 8.2: `${var}` string interpolation deprecated](https://php.watch/versions/8.2/${var}-string-interpolation-deprecated)
 - [RFC](https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation)