### PR TITLE
remove deprecated warning message on php8.1

### DIFF
--- a/lib/cli/arguments/Lexer.php
+++ b/lib/cli/arguments/Lexer.php
@@ -33,6 +33,7 @@ class Lexer extends Memoize implements \Iterator {
 	 *
 	 * @return string
 	 */
+	#[\ReturnTypeWillChange]
 	public function current() {
 		return $this->_item;
 	}
@@ -49,6 +50,7 @@ class Lexer extends Memoize implements \Iterator {
 	/**
 	 * Move the cursor forward 1 element if it is valid.
 	 */
+	#[\ReturnTypeWillChange]
 	public function next() {
 		if ($this->valid()) {
 			$this->_shift();
@@ -60,6 +62,7 @@ class Lexer extends Memoize implements \Iterator {
 	 *
 	 * @return int
 	 */
+	#[\ReturnTypeWillChange]
 	public function key() {
 		return $this->_index;
 	}
@@ -68,6 +71,7 @@ class Lexer extends Memoize implements \Iterator {
 	 * Move forward 1 element and, if the method hasn't been called before, reset
 	 * the cursor's position to 0.
 	 */
+	#[\ReturnTypeWillChange]
 	public function rewind() {
 		$this->_shift();
 		if ($this->_first) {
@@ -81,6 +85,7 @@ class Lexer extends Memoize implements \Iterator {
 	 *
 	 * @return bool
 	 */
+	#[\ReturnTypeWillChange]
 	public function valid() {
 		return ($this->_index < $this->_length);
 	}


### PR DESCRIPTION
added some `#[\ReturnTypeWillChange]` to suppress message like these :

```
Deprecated: Return type of cli\arguments\Lexer::current() should either be compatible with Iterator::current(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in vendor/wp-cli/php-cli-tools/lib/cli/arguments/Lexer.php on line 36
PHP Deprecated:  Return type of cli\arguments\Lexer::key() should either be compatible with Iterator::key(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in vendor/wp-cli/php-cli-tools/lib/cli/arguments/Lexer.php on line 64
```
