### PR TITLE
fix PHP Deprecated:  Creation of dynamic property

### DIFF
--- a/lib/cli/arguments/Lexer.php
+++ b/lib/cli/arguments/Lexer.php
@@ -15,6 +15,7 @@ namespace cli\arguments;
 use cli\Memoize;
 
 class Lexer extends Memoize implements \Iterator {
+	private $_item;
 	private $_items = array();
 	private $_index = 0;
 	private $_length = 0;


### PR DESCRIPTION
avoid the following error in php 8.2.* : 
PHP Deprecated:  Creation of dynamic property cli\arguments\Lexer::$_item is deprecated in wp-cli/php-cli-tools/lib/cli/arguments/Lexer.php on line 113