### PR TITLE
Prevent warnings in PHP 8.2 when `$col_values` is empty

### DIFF
--- a/lib/cli/table/Ascii.php
+++ b/lib/cli/table/Ascii.php
@@ -180,7 +180,7 @@ class Ascii extends Renderer {
 				$row_values = array();
 				$has_more = false;
 				foreach( $extra_rows as $col => &$col_values ) {
-					$row_values[ $col ] = array_shift( $col_values );
+					$row_values[ $col ] = ! empty( $col_values ) ? array_shift( $col_values ) : '';
 					if ( count( $col_values ) ) {
 						$has_more = true;
 					}


### PR DESCRIPTION
Fixes https://github.com/wp-cli/php-cli-tools/issues/159

Note: you'll need to resize your browser window in order to trigger the error warnings.

```
$  wp post create --post_title="Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tem por por por"
$ wp post list
```