### PR TITLE
Remove inexistent `post-install-cmd`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,9 +46,6 @@
         }
     },
     "scripts": {
-        "post-install-cmd": [
-            "./utils/git-setup-pre-commit-hook"
-        ],
         "behat": "run-behat-tests",
         "behat-rerun": "rerun-behat-tests",
         "lint": "run-linter-tests",


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/5480 and https://github.com/wp-cli/wp-cli/pull/5868 and https://github.com/wp-cli/wp-cli/issues/5859