### PR TITLE
Fix maxFlag to flagMax and maxOption to optionMax typos in HelpScreen class

### DIFF
--- a/lib/cli/arguments/HelpScreen.php
+++ b/lib/cli/arguments/HelpScreen.php
@@ -19,9 +19,9 @@ use cli\Arguments;
  */
 class HelpScreen {
 	protected $_flags = array();
-	protected $_maxFlag = 0;
+	protected $_flagMax = 0;
 	protected $_options = array();
-	protected $_maxOption = 0;
+	protected $_optionMax = 0;
 
 	public function __construct(Arguments $arguments) {
 		$this->setArguments($arguments);


### PR DESCRIPTION
Fixes #169 