### PR TITLE
PHP 8.4 | Fix implicitly nullable parameters

### DIFF
--- a/lib/cli/Table.php
+++ b/lib/cli/Table.php
@@ -44,11 +44,11 @@ class Table {
 	 * @param array  $rows     The rows of data for this table. Optional.
 	 * @param array  $footers  Footers used in this table. Optional.
 	 */
-	public function __construct(array $headers = null, array $rows = null, array $footers = null) {
+	public function __construct(array $headers = array(), array $rows = array(), array $footers = array()) {
 		if (!empty($headers)) {
 			// If all the rows is given in $headers we use the keys from the
 			// first row for the header values
-			if ($rows === null) {
+			if ($rows === array()) {
 				$rows = $headers;
 				$keys = array_keys(array_shift($headers));
 				$headers = array();


### PR DESCRIPTION
PHP 8.4 deprecates implicitly nullable parameters, i.e. typed parameters with a `null` default value, which are not explicitly declared as nullable.

As this code base still has a minimum supported PHP version of PHP 5.6, changing these parameters to explicitly nullable is not an option as that syntax was only introduced in PHP 7.1.

With that in mind, I'm proposing to change the default value of the parameters to comply with the type declaration.

Even though this is not a `final` class, this is not a breaking change for two reasons:
1. The signature check does not get applied to constructors.
2. Even if it did, default values can be different between parent vs child, as long as they comply with the expected type.

Ref: https://wiki.php.net/rfc/deprecate-implicitly-nullable-types