### PR TITLE
PHP 8.1: fix "passing null to non-nullable"

### DIFF
--- a/lib/cli/table/Ascii.php
+++ b/lib/cli/table/Ascii.php
@@ -137,7 +137,7 @@ class Ascii extends Renderer {
 			$extra_rows = array_fill( 0, count( $row ), array() );
 
 			foreach( $row as $col => $value ) {
-
+				$value = $value ?: '';
 				$value = str_replace( array( "\r\n", "\n" ), ' ', $value );
 
 				$col_width = $this->_widths[ $col ];


### PR DESCRIPTION
As of PHP 8.1, passing `null` to not explicitly nullable scalar parameters for PHP native functions is deprecated.

In this case, the `Test_Table_Ascii::testSpacingInTable()` method passes a row with the following values: `array('A2', '', ' C2', null)`. This then hits this deprecation in the `cli\table\Ascii::row()` method when calling the PHP native `str_replace()` function on line 141.

This can be seen when running the unit tests with `--display-deprecations`:
```
1) path/to/php-cli-tools/lib/cli/table/Ascii.php:141
str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated

Triggered by:

* Test_Table_Ascii::testSpacingInTable
  path/to/php-cli-tools/tests/Test_Table_Ascii.php:120
```

There are two options here:
1. Fix the test to pass an empty string instead of `null` for the fourth cell.
2. Fix the method under test to handle potential `null` values more elegantly.

I'm not sure what the desired solution is in this case, so I've implemented solution 2 to maintain the existing behaviour, but can change this to solution 1 if so desired.

Refs:
* https://wiki.php.net/rfc/deprecate_null_to_scalar_internal_arg