### PR TITLE
PHP 8.4 | Example code: remove use of `E_STRICT`

### DIFF
--- a/examples/common.php
+++ b/examples/common.php
@@ -4,7 +4,7 @@ if (php_sapi_name() != 'cli') {
 	die('Must run from command line');
 }
 
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 ini_set('display_errors', 1);
 ini_set('log_errors', 0);
 ini_set('html_errors', 0);


### PR DESCRIPTION
The `E_STRICT` constant is deprecated as of PHP 8.4 and will be removed in PHP 9.0 (commit went in today).

The error level hasn't been in use since PHP 8.0 anyway and was only barely still used in PHP 7.x, so removing the exclusion from the `error_reporting()` setting in the example code shouldn't really make any difference in practice.

Ref:
* https://wiki.php.net/rfc/deprecations_php_8_4#remove_e_strict_error_level_and_deprecate_e_strict_constant