### PR TITLE
Replace tabs in tables with 4 spaces

### DIFF
--- a/lib/cli/table/Ascii.php
+++ b/lib/cli/table/Ascii.php
@@ -198,7 +198,7 @@ class Ascii extends Renderer {
 	}
 
 	private function padColumn($content, $column) {
-		$content = str_replace( "\t", '    ', $content );
+		$content = str_replace( "\t", '    ', (string) $content );
 		return $this->_characters['padding'] . Colors::pad( $content, $this->_widths[ $column ], $this->isPreColorized( $column ) ) . $this->_characters['padding'];
 	}
 

--- a/lib/cli/table/Ascii.php
+++ b/lib/cli/table/Ascii.php
@@ -138,6 +138,7 @@ class Ascii extends Renderer {
 
 			foreach ( $row as $col => $value ) {
 				$value              = $value ?: '';
+				$value              = str_replace( "\t", '    ', $value );
 				$col_width          = $this->_widths[ $col ];
 				$encoding           = function_exists( 'mb_detect_encoding' ) ? mb_detect_encoding( $value, null, true /*strict*/ ) : false;
 				$original_val_width = Colors::width( $value, self::isPreColorized( $col ), $encoding );

--- a/lib/cli/table/Ascii.php
+++ b/lib/cli/table/Ascii.php
@@ -138,7 +138,6 @@ class Ascii extends Renderer {
 
 			foreach ( $row as $col => $value ) {
 				$value              = $value ?: '';
-				$value              = str_replace( "\t", '    ', $value );
 				$col_width          = $this->_widths[ $col ];
 				$encoding           = function_exists( 'mb_detect_encoding' ) ? mb_detect_encoding( $value, null, true /*strict*/ ) : false;
 				$original_val_width = Colors::width( $value, self::isPreColorized( $col ), $encoding );
@@ -199,6 +198,7 @@ class Ascii extends Renderer {
 	}
 
 	private function padColumn($content, $column) {
+		$content = str_replace( "\t", '    ', $content );
 		return $this->_characters['padding'] . Colors::pad( $content, $this->_widths[ $column ], $this->isPreColorized( $column ) ) . $this->_characters['padding'];
 	}
 


### PR DESCRIPTION
While testing #179, I realized that tabs (`\t`) have always slightly messed up table formatting due to tab length.

By replacing them with spaces, the length calculation is correct again.