### PR TITLE
Support line breaks and tab replacement in tabular table values

### DIFF
--- a/lib/cli/table/Tabular.php
+++ b/lib/cli/table/Tabular.php
@@ -22,7 +22,30 @@ class Tabular extends Renderer {
 	 * @param array  $row  The table row.
 	 * @return string  The formatted table row.
 	 */
-	public function row(array $row) {
-		return implode("\t", array_values($row));
+	public function row( array $row ) {
+		$rows   = [];
+		$output = '';
+
+		foreach ( $row as $col => $value ) {
+			$value       = str_replace( "\t", '    ', $value );
+			$split_lines = preg_split( '/\r\n|\n/', $value );
+			// Keep anything before the first line break on the original line
+			$row[ $col ] = array_shift( $split_lines );
+		}
+
+		$rows[] = $row;
+
+		foreach ( $split_lines as $i => $line ) {
+			if ( ! isset( $rows[ $i + 1 ] ) ) {
+				$rows[ $i + 1 ] = array_fill_keys( array_keys( $row ), '' );
+			}
+			$rows[ $i + 1 ][ $col ] = $line;
+		}
+
+		foreach ( $rows as $r ) {
+			$output .= implode( "\t", array_values( $r ) ) . PHP_EOL;
+		}
+
+		return trim( $output );
 	}
 }


### PR DESCRIPTION
This adds the same functionality from both #179 and #181 to the tabular table output. In WP CLI behat tests, the 'table containing rows' check can only use tabular table output so we need to fix it here as well in order for tests to work (as seen in https://github.com/wp-cli/wp-cli/pull/6055).

Before:
```
post_id	meta_key	meta_value
1	foo	foo
1	fruits	apple
banana
mango
1	bar	br
```
After:
```
post_id	meta_key	meta_value
1	foo	foo
1	fruits	apple
		banana
		mango
1	bar	br
```