### PR TITLE
Fix removal of trailing tab / whitespace in tabular table

### DIFF
--- a/lib/cli/table/Tabular.php
+++ b/lib/cli/table/Tabular.php
@@ -45,7 +45,6 @@ class Tabular extends Renderer {
 		foreach ( $rows as $r ) {
 			$output .= implode( "\t", array_values( $r ) ) . PHP_EOL;
 		}
-
-		return trim( $output );
+		return rtrim( $output, PHP_EOL );
 	}
 }

--- a/tests/Test_Table.php
+++ b/tests/Test_Table.php
@@ -245,4 +245,26 @@ class Test_Table extends TestCase {
 		$this->assertSame( 56, strlen( $out[6] ) );
 	}
 
+	public function test_preserve_trailing_tabs() {
+		$table    = new cli\Table();
+		$renderer = new cli\Table\Tabular();
+		$table->setRenderer( $renderer );
+
+		$table->setHeaders( array( 'Field', 'Type', 'Null', 'Key', 'Default', 'Extra' ) );
+
+		// Add row with missing values at the end
+		$table->addRow( array( 'date', 'date', 'NO', 'PRI', '', '' ) );
+		$table->addRow( array( 'awesome_stuff', 'text', 'YES', '', '', '' ) );
+
+		$out = $table->getDisplayLines();
+
+		$expected = [
+			"Field\tType\tNull\tKey\tDefault\tExtra",
+			"date\tdate\tNO\tPRI\t\t",
+			"awesome_stuff\ttext\tYES\t\t\t",
+		];
+
+		$this->assertSame( $expected, $out, 'Trailing tabs should be preserved in table output.' );
+	}
+
 }


### PR DESCRIPTION
Previously the final table output was trimmed with the intention of removing the last newline. This had an unintended side effect of removing the tab characters from empty columns in the specific case where the last row had one or more empty columns at the end of the row. This makes sure we are only removing the newline character as intended.

Add a new unit test to verify this behavior as well.

This fixes #183