### PR TITLE
Avoid deprecation warnings in newer PHP

### DIFF
--- a/lib/cli/table/Tabular.php
+++ b/lib/cli/table/Tabular.php
@@ -27,6 +27,7 @@ class Tabular extends Renderer {
 		$output = '';
 
 		foreach ( $row as $col => $value ) {
+			$value       = isset( $value ) ? (string) $value : '';
 			$value       = str_replace( "\t", '    ', $value );
 			$split_lines = preg_split( '/\r\n|\n/', $value );
 			// Keep anything before the first line break on the original line

--- a/tests/Test_Table.php
+++ b/tests/Test_Table.php
@@ -267,4 +267,26 @@ class Test_Table extends TestCase {
 		$this->assertSame( $expected, $out, 'Trailing tabs should be preserved in table output.' );
 	}
 
+	public function test_null_values_are_handled() {
+		$table    = new cli\Table();
+		$renderer = new cli\Table\Tabular();
+		$table->setRenderer( $renderer );
+
+		$table->setHeaders( array( 'Field', 'Type', 'Null', 'Key', 'Default', 'Extra' ) );
+
+		// Add row with a null value in the middle
+		$table->addRow( array( 'id', 'int', 'NO', 'PRI', null, 'auto_increment' ) );
+
+		// Add row with a null value at the end
+		$table->addRow( array( 'name', 'varchar(255)', 'YES', '', 'NULL', null ) );
+
+		$out = $table->getDisplayLines();
+
+		$expected = [
+			"Field\tType\tNull\tKey\tDefault\tExtra",
+			"id\tint\tNO\tPRI\t\tauto_increment",
+			"name\tvarchar(255)\tYES\t\tNULL\t",
+		];
+		$this->assertSame( $expected, $out, 'Null values should be safely converted to empty strings in table output.' );
+	}
 }


### PR DESCRIPTION
To avoid deprecation warnings in PHP 8.1+:
```
PHP Deprecated:  str_replace(): Passing null to parameter #3 ($subject)
of type array|string is deprecated in
/Users/isla/source/wp-cli-dev/php-cli-tools/lib/cli/table/Tabular.php on
line 30
```
I saw this while running tests for https://github.com/wp-cli/package-command/pull/197 where some rows of `wp package browse` look like:

```
        array(4) {
          [0]=>
          string(22) "redkiwi-nl/localconfig"
          [1]=>
          NULL
          [2]=>
          string(0) ""
          [3]=>
          string(54) "0.1, 0.2.1, 0.2.2, 0.3, 0.3.1, 9999999-dev, dev-master"
        }
        array(4) {
          [0]=>
          string(18) "vccw/scaffold-vccw"
          [1]=>
          NULL
          [2]=>
          string(0) ""
          [3]=>
          string(84) "1.0.0, 1.0.1, 1.1.0, 1.1.1, 1.2.0, 1.3.0, 1.4.0, 9999999-dev, dev-master, dev-stable"
        }
        array(4) {
          [0]=>
          string(22) "welaika/wp-cli-db2utf8"
          [1]=>
          NULL
          [2]=>
          string(0) ""
          [3]=>
          string(23) "9999999-dev, dev-master"
        }
```